### PR TITLE
Add HTTP search tool handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,6 +983,7 @@ dependencies = [
  "lean-mcp-core",
  "predicates",
  "regex",
+ "reqwest",
  "rmcp",
  "serde",
  "serde_json",
@@ -992,6 +993,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -2831,18 +2833,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/lean-mcp-server/Cargo.toml
+++ b/crates/lean-mcp-server/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 lean-lsp-client = { path = "../lean-lsp-client" }
 lean-mcp-core = { path = "../lean-mcp-core" }
 regex = "1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 rmcp = { version = "0.1", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -28,6 +29,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 assert_cmd = "2"
 async-trait = "0.1"
 predicates = "3"
+serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util", "macros"] }
 tokio-test = "0.4"
+wiremock = "0.6"

--- a/crates/lean-mcp-server/src/tools/code_actions.rs
+++ b/crates/lean-mcp-server/src/tools/code_actions.rs
@@ -1,0 +1,849 @@
+//! Tool handler for `lean_code_actions`.
+//!
+//! Retrieves available code actions (quick fixes, refactorings) for a given
+//! line in a Lean file. Diagnostics on the target line are used to determine
+//! the ranges to query. Actions are deduplicated by title and resolved to
+//! extract concrete text edits.
+
+use std::collections::HashSet;
+
+use lean_lsp_client::client::LspClient;
+use lean_mcp_core::error::LeanToolError;
+use lean_mcp_core::models::{CodeAction, CodeActionEdit, CodeActionsResult};
+use serde_json::Value;
+
+/// Handle a `lean_code_actions` tool call.
+///
+/// Retrieves code actions for the given line by:
+/// 1. Opening the file and fetching diagnostics for the target line.
+/// 2. Querying code actions for each diagnostic range on that line.
+/// 3. Deduplicating actions by title.
+/// 4. Resolving unresolved actions via `get_code_action_resolve`.
+/// 5. Extracting text edits, converting LSP 0-indexed positions to 1-indexed.
+///
+/// `line` is **1-indexed** (matching the MCP tool interface).
+/// It is converted to 0-indexed for LSP calls internally.
+pub async fn handle_code_actions(
+    client: &dyn LspClient,
+    file_path: &str,
+    line: u32,
+) -> Result<CodeActionsResult, LeanToolError> {
+    // 1. Open the file in the LSP server.
+    client
+        .open_file(file_path)
+        .await
+        .map_err(|e| LeanToolError::LspError {
+            operation: "open_file".into(),
+            message: e.to_string(),
+        })?;
+
+    // 2. Convert 1-indexed line to 0-indexed for LSP.
+    let lsp_line = line.saturating_sub(1);
+
+    // 3. Get diagnostics for the target line.
+    let diags_response = client
+        .get_diagnostics(file_path, Some(lsp_line), Some(lsp_line), Some(15.0))
+        .await
+        .map_err(|e| LeanToolError::LspError {
+            operation: "get_diagnostics".into(),
+            message: e.to_string(),
+        })?;
+
+    let diagnostics = diags_response
+        .get("diagnostics")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    // 4. Collect diagnostic ranges on the target line.
+    let ranges = extract_diagnostic_ranges(&diagnostics, lsp_line);
+
+    // 5. If no diagnostics on this line, return empty actions.
+    if ranges.is_empty() {
+        return Ok(CodeActionsResult { actions: vec![] });
+    }
+
+    // 6. Query code actions for each diagnostic range and deduplicate by title.
+    let mut seen_titles = HashSet::new();
+    let mut raw_actions: Vec<Value> = Vec::new();
+
+    for (start_line, start_col, end_line, end_col) in &ranges {
+        let actions = client
+            .get_code_actions(file_path, *start_line, *start_col, *end_line, *end_col)
+            .await
+            .map_err(|e| LeanToolError::LspError {
+                operation: "get_code_actions".into(),
+                message: e.to_string(),
+            })?;
+
+        for action in actions {
+            let title = action
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if !title.is_empty() && seen_titles.insert(title) {
+                raw_actions.push(action);
+            }
+        }
+    }
+
+    // 7. Resolve unresolved actions and extract edits.
+    let mut result_actions: Vec<CodeAction> = Vec::new();
+
+    for action in raw_actions {
+        let resolved = resolve_action(client, action).await?;
+        let title = resolved
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let is_preferred = resolved
+            .get("isPreferred")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let edits = extract_edits(&resolved);
+
+        result_actions.push(CodeAction {
+            title,
+            is_preferred,
+            edits,
+        });
+    }
+
+    Ok(CodeActionsResult {
+        actions: result_actions,
+    })
+}
+
+/// Extract diagnostic ranges that fall on the target line (0-indexed).
+///
+/// Returns a vec of `(start_line, start_col, end_line, end_col)` tuples,
+/// all 0-indexed.
+fn extract_diagnostic_ranges(diagnostics: &[Value], target_line: u32) -> Vec<(u32, u32, u32, u32)> {
+    let mut ranges = Vec::new();
+
+    for diag in diagnostics {
+        let range = diag.get("fullRange").or_else(|| diag.get("range"));
+        let Some(r) = range else { continue };
+
+        let start_line = r
+            .pointer("/start/line")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+        let start_col = r
+            .pointer("/start/character")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+        let end_line = r.pointer("/end/line").and_then(Value::as_u64).unwrap_or(0) as u32;
+        let end_col = r
+            .pointer("/end/character")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+
+        // Include diagnostics whose range overlaps the target line.
+        if start_line <= target_line && end_line >= target_line {
+            ranges.push((start_line, start_col, end_line, end_col));
+        }
+    }
+
+    ranges
+}
+
+/// Resolve a code action if it lacks edits (i.e., is unresolved).
+///
+/// An action is considered unresolved if it has no `edit` field.
+/// In that case, `get_code_action_resolve` is called to obtain the full action.
+async fn resolve_action(client: &dyn LspClient, action: Value) -> Result<Value, LeanToolError> {
+    if action.get("edit").is_some() {
+        return Ok(action);
+    }
+
+    client
+        .get_code_action_resolve(action)
+        .await
+        .map_err(|e| LeanToolError::LspError {
+            operation: "get_code_action_resolve".into(),
+            message: e.to_string(),
+        })
+}
+
+/// Extract text edits from a resolved code action.
+///
+/// Looks for edits in `edit.documentChanges[].edits[]` and
+/// `edit.changes.*[]`, converting LSP 0-indexed positions to 1-indexed.
+fn extract_edits(action: &Value) -> Vec<CodeActionEdit> {
+    let mut edits = Vec::new();
+
+    // Try documentChanges first.
+    if let Some(doc_changes) = action
+        .pointer("/edit/documentChanges")
+        .and_then(Value::as_array)
+    {
+        for doc_change in doc_changes {
+            if let Some(text_edits) = doc_change.get("edits").and_then(Value::as_array) {
+                for edit in text_edits {
+                    if let Some(e) = convert_text_edit(edit) {
+                        edits.push(e);
+                    }
+                }
+            }
+        }
+    }
+
+    // Also try changes (flat map of uri -> edits[]).
+    if let Some(changes) = action.pointer("/edit/changes").and_then(Value::as_object) {
+        for (_uri, uri_edits) in changes {
+            if let Some(edit_array) = uri_edits.as_array() {
+                for edit in edit_array {
+                    if let Some(e) = convert_text_edit(edit) {
+                        edits.push(e);
+                    }
+                }
+            }
+        }
+    }
+
+    edits
+}
+
+/// Convert a single LSP TextEdit to a `CodeActionEdit` with 1-indexed positions.
+fn convert_text_edit(edit: &Value) -> Option<CodeActionEdit> {
+    let range = edit.get("range")?;
+    let new_text = edit.get("newText").and_then(Value::as_str)?;
+
+    let start_line = range
+        .pointer("/start/line")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        + 1;
+    let start_col = range
+        .pointer("/start/character")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        + 1;
+    let end_line = range
+        .pointer("/end/line")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        + 1;
+    let end_col = range
+        .pointer("/end/character")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        + 1;
+
+    Some(CodeActionEdit {
+        new_text: new_text.to_string(),
+        start_line,
+        start_column: start_col,
+        end_line,
+        end_column: end_col,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use lean_lsp_client::client::{LspClient, LspClientError};
+    use serde_json::json;
+    use std::path::{Path, PathBuf};
+
+    /// Mock LSP client for code actions handler tests.
+    struct MockCodeActionClient {
+        project: PathBuf,
+        /// Canned response for `get_diagnostics`.
+        diagnostics_response: Value,
+        /// Canned response for `get_code_actions`.
+        code_actions_response: Vec<Value>,
+        /// Canned response for `get_code_action_resolve`.
+        resolve_response: Value,
+    }
+
+    impl MockCodeActionClient {
+        fn new() -> Self {
+            Self {
+                project: PathBuf::from("/test/project"),
+                diagnostics_response: json!({
+                    "diagnostics": [],
+                    "success": true
+                }),
+                code_actions_response: Vec::new(),
+                resolve_response: json!({}),
+            }
+        }
+
+        fn with_diagnostics(mut self, diags: Vec<Value>) -> Self {
+            self.diagnostics_response = json!({
+                "diagnostics": diags,
+                "success": true
+            });
+            self
+        }
+
+        fn with_code_actions(mut self, actions: Vec<Value>) -> Self {
+            self.code_actions_response = actions;
+            self
+        }
+
+        fn with_resolve(mut self, resolved: Value) -> Self {
+            self.resolve_response = resolved;
+            self
+        }
+    }
+
+    #[async_trait]
+    impl LspClient for MockCodeActionClient {
+        fn project_path(&self) -> &Path {
+            &self.project
+        }
+        async fn open_file(&self, _p: &str) -> Result<(), LspClientError> {
+            Ok(())
+        }
+        async fn open_file_force(&self, _p: &str) -> Result<(), LspClientError> {
+            Ok(())
+        }
+        async fn get_file_content(&self, _p: &str) -> Result<String, LspClientError> {
+            Ok(String::new())
+        }
+        async fn update_file(&self, _p: &str, _c: Vec<Value>) -> Result<(), LspClientError> {
+            Ok(())
+        }
+        async fn update_file_content(&self, _p: &str, _c: &str) -> Result<(), LspClientError> {
+            Ok(())
+        }
+        async fn close_files(&self, _p: &[String]) -> Result<(), LspClientError> {
+            Ok(())
+        }
+        async fn get_diagnostics(
+            &self,
+            _p: &str,
+            _sl: Option<u32>,
+            _el: Option<u32>,
+            _t: Option<f64>,
+        ) -> Result<Value, LspClientError> {
+            Ok(self.diagnostics_response.clone())
+        }
+        async fn get_interactive_diagnostics(
+            &self,
+            _p: &str,
+            _sl: Option<u32>,
+            _el: Option<u32>,
+        ) -> Result<Vec<Value>, LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_goal(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Option<Value>, LspClientError> {
+            Ok(None)
+        }
+        async fn get_term_goal(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Option<Value>, LspClientError> {
+            Ok(None)
+        }
+        async fn get_hover(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Option<Value>, LspClientError> {
+            Ok(None)
+        }
+        async fn get_completions(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Vec<Value>, LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_declarations(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Vec<Value>, LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_references(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+            _d: bool,
+        ) -> Result<Vec<Value>, LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_document_symbols(&self, _p: &str) -> Result<Vec<Value>, LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_code_actions(
+            &self,
+            _p: &str,
+            _sl: u32,
+            _sc: u32,
+            _el: u32,
+            _ec: u32,
+        ) -> Result<Vec<Value>, LspClientError> {
+            Ok(self.code_actions_response.clone())
+        }
+        async fn get_code_action_resolve(&self, _a: Value) -> Result<Value, LspClientError> {
+            Ok(self.resolve_response.clone())
+        }
+        async fn get_widgets(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Vec<Value>, LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_widget_source(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+            _h: &str,
+        ) -> Result<Value, LspClientError> {
+            Ok(json!({}))
+        }
+        async fn shutdown(&self) -> Result<(), LspClientError> {
+            Ok(())
+        }
+    }
+
+    // ---- returns actions with edits ----
+
+    #[tokio::test]
+    async fn code_actions_returns_actions_with_edits() {
+        let client = MockCodeActionClient::new()
+            .with_diagnostics(vec![json!({
+                "range": {
+                    "start": {"line": 4, "character": 2},
+                    "end": {"line": 4, "character": 10}
+                },
+                "severity": 1,
+                "message": "unknown tactic"
+            })])
+            .with_code_actions(vec![json!({
+                "title": "Try this: simp only [Nat.add_comm]",
+                "isPreferred": true,
+                "edit": {
+                    "documentChanges": [{
+                        "edits": [{
+                            "range": {
+                                "start": {"line": 4, "character": 2},
+                                "end": {"line": 4, "character": 10}
+                            },
+                            "newText": "simp only [Nat.add_comm]"
+                        }]
+                    }]
+                }
+            })]);
+
+        let result = handle_code_actions(&client, "Main.lean", 5).await.unwrap();
+
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(
+            result.actions[0].title,
+            "Try this: simp only [Nat.add_comm]"
+        );
+        assert!(result.actions[0].is_preferred);
+        assert_eq!(result.actions[0].edits.len(), 1);
+        assert_eq!(
+            result.actions[0].edits[0].new_text,
+            "simp only [Nat.add_comm]"
+        );
+        // Positions should be 1-indexed: line 4 -> 5, char 2 -> 3
+        assert_eq!(result.actions[0].edits[0].start_line, 5);
+        assert_eq!(result.actions[0].edits[0].start_column, 3);
+        assert_eq!(result.actions[0].edits[0].end_line, 5);
+        assert_eq!(result.actions[0].edits[0].end_column, 11);
+    }
+
+    // ---- deduplicates by title ----
+
+    #[tokio::test]
+    async fn code_actions_deduplicates_by_title() {
+        let client = MockCodeActionClient::new()
+            .with_diagnostics(vec![
+                json!({
+                    "range": {
+                        "start": {"line": 2, "character": 0},
+                        "end": {"line": 2, "character": 5}
+                    },
+                    "severity": 1,
+                    "message": "error 1"
+                }),
+                json!({
+                    "range": {
+                        "start": {"line": 2, "character": 3},
+                        "end": {"line": 2, "character": 8}
+                    },
+                    "severity": 1,
+                    "message": "error 2"
+                }),
+            ])
+            .with_code_actions(vec![
+                json!({
+                    "title": "Try this: exact rfl",
+                    "edit": {
+                        "documentChanges": [{
+                            "edits": [{
+                                "range": {
+                                    "start": {"line": 2, "character": 0},
+                                    "end": {"line": 2, "character": 5}
+                                },
+                                "newText": "exact rfl"
+                            }]
+                        }]
+                    }
+                }),
+                json!({
+                    "title": "Try this: exact rfl",
+                    "edit": {
+                        "documentChanges": [{
+                            "edits": [{
+                                "range": {
+                                    "start": {"line": 2, "character": 0},
+                                    "end": {"line": 2, "character": 5}
+                                },
+                                "newText": "exact rfl"
+                            }]
+                        }]
+                    }
+                }),
+            ]);
+
+        let result = handle_code_actions(&client, "Main.lean", 3).await.unwrap();
+
+        // Despite two diagnostics producing the same action title, only one should appear.
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(result.actions[0].title, "Try this: exact rfl");
+    }
+
+    // ---- resolves unresolved actions ----
+
+    #[tokio::test]
+    async fn code_actions_resolves_unresolved_actions() {
+        let client = MockCodeActionClient::new()
+            .with_diagnostics(vec![json!({
+                "range": {
+                    "start": {"line": 5, "character": 0},
+                    "end": {"line": 5, "character": 10}
+                },
+                "severity": 2,
+                "message": "unused variable"
+            })])
+            .with_code_actions(vec![json!({
+                "title": "Remove unused variable",
+                "kind": "quickfix"
+                // No "edit" field - this action needs to be resolved.
+            })])
+            .with_resolve(json!({
+                "title": "Remove unused variable",
+                "isPreferred": false,
+                "edit": {
+                    "changes": {
+                        "file:///test/Main.lean": [{
+                            "range": {
+                                "start": {"line": 5, "character": 0},
+                                "end": {"line": 5, "character": 10}
+                            },
+                            "newText": ""
+                        }]
+                    }
+                }
+            }));
+
+        let result = handle_code_actions(&client, "Main.lean", 6).await.unwrap();
+
+        assert_eq!(result.actions.len(), 1);
+        assert_eq!(result.actions[0].title, "Remove unused variable");
+        assert!(!result.actions[0].is_preferred);
+        assert_eq!(result.actions[0].edits.len(), 1);
+        assert_eq!(result.actions[0].edits[0].new_text, "");
+    }
+
+    // ---- empty line returns empty actions ----
+
+    #[tokio::test]
+    async fn code_actions_empty_line_returns_empty_actions() {
+        let client = MockCodeActionClient::new();
+
+        let result = handle_code_actions(&client, "Main.lean", 1).await.unwrap();
+
+        assert!(result.actions.is_empty());
+    }
+
+    // ---- positions are 1-indexed in output ----
+
+    #[tokio::test]
+    async fn code_actions_positions_are_1_indexed_in_output() {
+        let client = MockCodeActionClient::new()
+            .with_diagnostics(vec![json!({
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 5}
+                },
+                "severity": 1,
+                "message": "error"
+            })])
+            .with_code_actions(vec![json!({
+                "title": "Fix it",
+                "edit": {
+                    "documentChanges": [{
+                        "edits": [{
+                            "range": {
+                                "start": {"line": 0, "character": 0},
+                                "end": {"line": 0, "character": 5}
+                            },
+                            "newText": "fixed"
+                        }]
+                    }]
+                }
+            })]);
+
+        let result = handle_code_actions(&client, "Main.lean", 1).await.unwrap();
+
+        assert_eq!(result.actions.len(), 1);
+        let edit = &result.actions[0].edits[0];
+        // LSP (0,0)-(0,5) should become 1-indexed (1,1)-(1,6)
+        assert_eq!(edit.start_line, 1);
+        assert_eq!(edit.start_column, 1);
+        assert_eq!(edit.end_line, 1);
+        assert_eq!(edit.end_column, 6);
+    }
+
+    // ---- multiple actions with different titles are all returned ----
+
+    #[tokio::test]
+    async fn code_actions_returns_multiple_distinct_actions() {
+        let client = MockCodeActionClient::new()
+            .with_diagnostics(vec![json!({
+                "range": {
+                    "start": {"line": 3, "character": 0},
+                    "end": {"line": 3, "character": 15}
+                },
+                "severity": 1,
+                "message": "type mismatch"
+            })])
+            .with_code_actions(vec![
+                json!({
+                    "title": "Try this: simp",
+                    "edit": {
+                        "documentChanges": [{
+                            "edits": [{
+                                "range": {
+                                    "start": {"line": 3, "character": 0},
+                                    "end": {"line": 3, "character": 15}
+                                },
+                                "newText": "simp"
+                            }]
+                        }]
+                    }
+                }),
+                json!({
+                    "title": "Try this: ring",
+                    "edit": {
+                        "documentChanges": [{
+                            "edits": [{
+                                "range": {
+                                    "start": {"line": 3, "character": 0},
+                                    "end": {"line": 3, "character": 15}
+                                },
+                                "newText": "ring"
+                            }]
+                        }]
+                    }
+                }),
+            ]);
+
+        let result = handle_code_actions(&client, "Main.lean", 4).await.unwrap();
+
+        assert_eq!(result.actions.len(), 2);
+        assert_eq!(result.actions[0].title, "Try this: simp");
+        assert_eq!(result.actions[1].title, "Try this: ring");
+    }
+
+    // ---- extract_diagnostic_ranges unit tests ----
+
+    #[test]
+    fn extract_ranges_filters_by_target_line() {
+        let diags = vec![
+            json!({
+                "range": {
+                    "start": {"line": 3, "character": 0},
+                    "end": {"line": 3, "character": 10}
+                }
+            }),
+            json!({
+                "range": {
+                    "start": {"line": 5, "character": 2},
+                    "end": {"line": 5, "character": 8}
+                }
+            }),
+        ];
+        let ranges = extract_diagnostic_ranges(&diags, 3);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0], (3, 0, 3, 10));
+    }
+
+    #[test]
+    fn extract_ranges_includes_multiline_diagnostic_spanning_target() {
+        let diags = vec![json!({
+            "range": {
+                "start": {"line": 2, "character": 0},
+                "end": {"line": 6, "character": 5}
+            }
+        })];
+        let ranges = extract_diagnostic_ranges(&diags, 4);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0], (2, 0, 6, 5));
+    }
+
+    #[test]
+    fn extract_ranges_empty_when_no_match() {
+        let diags = vec![json!({
+            "range": {
+                "start": {"line": 10, "character": 0},
+                "end": {"line": 10, "character": 5}
+            }
+        })];
+        let ranges = extract_diagnostic_ranges(&diags, 0);
+        assert!(ranges.is_empty());
+    }
+
+    // ---- convert_text_edit unit tests ----
+
+    #[test]
+    fn convert_text_edit_converts_0_to_1_indexed() {
+        let edit = json!({
+            "range": {
+                "start": {"line": 9, "character": 4},
+                "end": {"line": 9, "character": 12}
+            },
+            "newText": "replacement"
+        });
+        let result = convert_text_edit(&edit).unwrap();
+        assert_eq!(result.new_text, "replacement");
+        assert_eq!(result.start_line, 10);
+        assert_eq!(result.start_column, 5);
+        assert_eq!(result.end_line, 10);
+        assert_eq!(result.end_column, 13);
+    }
+
+    #[test]
+    fn convert_text_edit_returns_none_without_range() {
+        let edit = json!({"newText": "foo"});
+        assert!(convert_text_edit(&edit).is_none());
+    }
+
+    #[test]
+    fn convert_text_edit_returns_none_without_new_text() {
+        let edit = json!({
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 0, "character": 3}
+            }
+        });
+        assert!(convert_text_edit(&edit).is_none());
+    }
+
+    // ---- extract_edits unit tests ----
+
+    #[test]
+    fn extract_edits_from_document_changes() {
+        let action = json!({
+            "title": "Fix",
+            "edit": {
+                "documentChanges": [{
+                    "edits": [
+                        {
+                            "range": {
+                                "start": {"line": 1, "character": 0},
+                                "end": {"line": 1, "character": 5}
+                            },
+                            "newText": "hello"
+                        },
+                        {
+                            "range": {
+                                "start": {"line": 3, "character": 2},
+                                "end": {"line": 3, "character": 7}
+                            },
+                            "newText": "world"
+                        }
+                    ]
+                }]
+            }
+        });
+        let edits = extract_edits(&action);
+        assert_eq!(edits.len(), 2);
+        assert_eq!(edits[0].new_text, "hello");
+        assert_eq!(edits[0].start_line, 2); // 1-indexed
+        assert_eq!(edits[1].new_text, "world");
+        assert_eq!(edits[1].start_line, 4); // 1-indexed
+    }
+
+    #[test]
+    fn extract_edits_from_changes_map() {
+        let action = json!({
+            "title": "Fix",
+            "edit": {
+                "changes": {
+                    "file:///test/Main.lean": [{
+                        "range": {
+                            "start": {"line": 0, "character": 0},
+                            "end": {"line": 0, "character": 3}
+                        },
+                        "newText": "new"
+                    }]
+                }
+            }
+        });
+        let edits = extract_edits(&action);
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].new_text, "new");
+        assert_eq!(edits[0].start_line, 1);
+        assert_eq!(edits[0].start_column, 1);
+    }
+
+    #[test]
+    fn extract_edits_empty_when_no_edit_field() {
+        let action = json!({"title": "No edits"});
+        let edits = extract_edits(&action);
+        assert!(edits.is_empty());
+    }
+
+    // ---- extract_ranges with fullRange ----
+
+    #[test]
+    fn extract_ranges_prefers_full_range() {
+        let diags = vec![json!({
+            "range": {
+                "start": {"line": 10, "character": 0},
+                "end": {"line": 10, "character": 5}
+            },
+            "fullRange": {
+                "start": {"line": 3, "character": 0},
+                "end": {"line": 7, "character": 10}
+            }
+        })];
+        // Target line 5 is within fullRange (3-7) but not within range (10-10).
+        let ranges = extract_diagnostic_ranges(&diags, 5);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0], (3, 0, 7, 10));
+    }
+}

--- a/crates/lean-mcp-server/src/tools/mod.rs
+++ b/crates/lean-mcp-server/src/tools/mod.rs
@@ -1,6 +1,8 @@
 // Tool handlers are wired into MCP routing in a follow-up issue.
 // Suppress dead-code warnings until then.
 #[allow(dead_code)]
+pub mod code_actions;
+#[allow(dead_code)]
 pub mod completions;
 #[allow(dead_code)]
 pub mod declarations;
@@ -14,5 +16,7 @@ pub mod hover;
 pub mod references;
 #[allow(dead_code)]
 pub mod run_code;
+#[allow(dead_code)]
+pub mod search;
 #[allow(dead_code)]
 pub mod widgets;

--- a/crates/lean-mcp-server/src/tools/search.rs
+++ b/crates/lean-mcp-server/src/tools/search.rs
@@ -1,0 +1,1332 @@
+//! HTTP-based search tool handlers.
+//!
+//! Five external search tools that call remote APIs:
+//! - `lean_leansearch` -- natural language to Mathlib via leansearch.net
+//! - `lean_loogle` (remote) -- type-pattern search via loogle.lean-lang.org
+//! - `lean_leanfinder` -- semantic/conceptual search via HuggingFace endpoint
+//! - `lean_state_search` -- goal-based lemma search via premise-search.com
+//! - `lean_hammer_premise` -- goal-based premise retrieval via leanpremise.net
+//!
+//! All handlers accept configurable base URLs (for wiremock testing) and use
+//! `reqwest` for HTTP.
+
+use lean_lsp_client::client::LspClient;
+use lean_mcp_core::error::LeanToolError;
+use lean_mcp_core::models::{
+    LeanFinderResult, LeanFinderResults, LeanSearchResult, LeanSearchResults, LoogleResult,
+    LoogleResults, PremiseResult, PremiseResults, StateSearchResult, StateSearchResults,
+};
+use lean_mcp_core::utils::extract_goals_list;
+use serde_json::Value;
+
+/// Default base URL for LeanSearch.
+const LEANSEARCH_DEFAULT_URL: &str = "https://leansearch.net";
+
+/// Default base URL for Loogle.
+const LOOGLE_DEFAULT_URL: &str = "https://loogle.lean-lang.org";
+
+/// Default base URL for LeanFinder (HuggingFace endpoint).
+const LEANFINDER_DEFAULT_URL: &str =
+    "https://bxrituxuhpc70w8w.us-east-1.aws.endpoints.huggingface.cloud";
+
+/// Default base URL for state search (premise-search.com).
+const STATE_SEARCH_DEFAULT_URL: &str = "https://premise-search.com";
+
+/// Default base URL for hammer premise (leanpremise.net).
+const HAMMER_PREMISE_DEFAULT_URL: &str = "http://leanpremise.net";
+
+/// Default HTTP timeout in seconds.
+const HTTP_TIMEOUT_SECS: u64 = 30;
+
+/// Configuration for search tool base URLs.
+///
+/// All URLs should be without a trailing slash. For production use, the
+/// defaults point to the real external services. For tests, set the URL
+/// to a `wiremock::MockServer` address.
+#[derive(Debug, Clone)]
+pub struct SearchConfig {
+    /// Base URL for the LeanSearch API.
+    pub leansearch_url: String,
+    /// Base URL for the Loogle API.
+    pub loogle_url: String,
+    /// Base URL for the LeanFinder API.
+    pub leanfinder_url: String,
+    /// Base URL for the state search API.
+    pub state_search_url: String,
+    /// Base URL for the hammer premise API.
+    pub hammer_premise_url: String,
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            leansearch_url: std::env::var("LEANSEARCH_URL")
+                .unwrap_or_else(|_| LEANSEARCH_DEFAULT_URL.to_string()),
+            loogle_url: std::env::var("LOOGLE_URL")
+                .unwrap_or_else(|_| LOOGLE_DEFAULT_URL.to_string()),
+            leanfinder_url: std::env::var("LEANFINDER_URL")
+                .unwrap_or_else(|_| LEANFINDER_DEFAULT_URL.to_string()),
+            state_search_url: std::env::var("STATE_SEARCH_URL")
+                .unwrap_or_else(|_| STATE_SEARCH_DEFAULT_URL.to_string()),
+            hammer_premise_url: std::env::var("HAMMER_PREMISE_URL")
+                .unwrap_or_else(|_| HAMMER_PREMISE_DEFAULT_URL.to_string()),
+        }
+    }
+}
+
+/// Build a shared `reqwest::Client` with a reasonable timeout.
+fn http_client() -> Result<reqwest::Client, LeanToolError> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| LeanToolError::Other(format!("Failed to build HTTP client: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// lean_leansearch
+// ---------------------------------------------------------------------------
+
+/// Handle `lean_leansearch`: POST to LeanSearch API.
+///
+/// Sends a JSON body `{"num_results": "<n>", "query": ["<query>"]}` and
+/// parses the nested response structure.
+///
+/// Rate limit category: `leansearch` (3/30s).
+pub async fn handle_leansearch(
+    query: &str,
+    num_results: usize,
+    config: &SearchConfig,
+) -> Result<LeanSearchResults, LeanToolError> {
+    let client = http_client()?;
+    let url = format!("{}/search", config.leansearch_url);
+
+    let body = serde_json::json!({
+        "num_results": num_results.to_string(),
+        "query": [query],
+    });
+
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("LeanSearch HTTP error: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(LeanToolError::Other(format!(
+            "LeanSearch returned status {}",
+            response.status()
+        )));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("LeanSearch JSON parse error: {e}")))?;
+
+    // Response format: {"results": [[{"result": {...}}, ...]]}
+    // results[0] is the array of hits for the first query.
+    let items = parse_leansearch_results(&resp_json);
+
+    Ok(LeanSearchResults { items })
+}
+
+/// Parse the nested LeanSearch response.
+///
+/// The API returns `results[0][i].result` where each result has:
+/// - `name`: array of strings -> joined
+/// - `module_name`: array of strings -> joined
+/// - `kind`: string
+/// - `type`: array of strings -> joined
+fn parse_leansearch_results(json: &Value) -> Vec<LeanSearchResult> {
+    let Some(results) = json.get("results").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    let Some(first_query) = results.first().and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+
+    first_query
+        .iter()
+        .filter_map(|entry| {
+            let result = entry.get("result")?;
+
+            let name = join_string_array(result.get("name")?);
+            let module_name = join_string_array(result.get("module_name")?);
+            let kind = result
+                .get("kind")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let r#type = result.get("type").map(join_string_array);
+
+            Some(LeanSearchResult {
+                name,
+                module_name,
+                kind,
+                r#type,
+            })
+        })
+        .collect()
+}
+
+/// Join a JSON value that is either a string or an array of strings.
+fn join_string_array(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|x| x.as_str())
+            .collect::<Vec<_>>()
+            .join(""),
+        _ => String::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// lean_loogle (remote)
+// ---------------------------------------------------------------------------
+
+/// Handle `lean_loogle` (remote): GET to Loogle API.
+///
+/// Sends `GET /json?q={url_encoded_query}` and parses the `hits` array.
+///
+/// Rate limit category: `loogle` (3/30s).
+pub async fn handle_loogle_remote(
+    query: &str,
+    num_results: usize,
+    config: &SearchConfig,
+) -> Result<LoogleResults, LeanToolError> {
+    let client = http_client()?;
+    let url = format!("{}/json", config.loogle_url);
+
+    let response = client
+        .get(&url)
+        .query(&[("q", query)])
+        .send()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("Loogle HTTP error: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(LeanToolError::Other(format!(
+            "Loogle returned status {}",
+            response.status()
+        )));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("Loogle JSON parse error: {e}")))?;
+
+    // Check for error/suggestion messages
+    if let Some(error) = resp_json.get("error").and_then(|v| v.as_str()) {
+        return Err(LeanToolError::Other(format!("Loogle error: {error}")));
+    }
+
+    let items = parse_loogle_results(&resp_json, num_results);
+
+    Ok(LoogleResults { items })
+}
+
+/// Parse Loogle hits.
+///
+/// Response: `{"hits": [{"name": "...", "type": "...", "module": "..."}, ...]}`
+fn parse_loogle_results(json: &Value, num_results: usize) -> Vec<LoogleResult> {
+    let Some(hits) = json.get("hits").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+
+    hits.iter()
+        .take(num_results)
+        .filter_map(|hit| {
+            let name = hit.get("name")?.as_str()?.to_string();
+            let r#type = hit.get("type")?.as_str()?.to_string();
+            let module = hit.get("module")?.as_str()?.to_string();
+            Some(LoogleResult {
+                name,
+                r#type,
+                module,
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// lean_leanfinder
+// ---------------------------------------------------------------------------
+
+/// Handle `lean_leanfinder`: POST to HuggingFace endpoint.
+///
+/// Sends `{"inputs": "<query>", "top_k": <n>}` and filters results to
+/// Mathlib4 entries, extracting `full_name` from the URL pattern.
+///
+/// Rate limit category: `leanfinder` (10/30s).
+pub async fn handle_leanfinder(
+    query: &str,
+    num_results: usize,
+    config: &SearchConfig,
+) -> Result<LeanFinderResults, LeanToolError> {
+    let client = http_client()?;
+    let url = config.leanfinder_url.clone();
+
+    let body = serde_json::json!({
+        "inputs": query,
+        "top_k": num_results,
+    });
+
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("LeanFinder HTTP error: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(LeanToolError::Other(format!(
+            "LeanFinder returned status {}",
+            response.status()
+        )));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("LeanFinder JSON parse error: {e}")))?;
+
+    let items = parse_leanfinder_results(&resp_json);
+
+    Ok(LeanFinderResults { items })
+}
+
+/// Parse LeanFinder results, filtering to mathlib4 entries.
+///
+/// Response is an array of objects with:
+/// - `corpus`: must contain "mathlib4"
+/// - `url`: contains the full_name after the last `/` (URL-decoded)
+/// - `formal_statement`: the Lean type signature
+/// - `informal_statement`: natural language description
+fn parse_leanfinder_results(json: &Value) -> Vec<LeanFinderResult> {
+    let Some(arr) = json.as_array() else {
+        return Vec::new();
+    };
+
+    arr.iter()
+        .filter_map(|entry| {
+            // Filter to mathlib4 results
+            let corpus = entry.get("corpus")?.as_str()?;
+            if !corpus.contains("mathlib4") {
+                return None;
+            }
+
+            let url = entry.get("url")?.as_str()?;
+            let full_name = extract_name_from_url(url);
+
+            let formal_statement = entry
+                .get("formal_statement")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            let informal_statement = entry
+                .get("informal_statement")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            Some(LeanFinderResult {
+                full_name,
+                formal_statement,
+                informal_statement,
+            })
+        })
+        .collect()
+}
+
+/// Extract the declaration name from a Mathlib URL.
+///
+/// E.g. `https://leanprover-community.github.io/mathlib4_docs/Mathlib/.../Foo.Bar.html`
+/// yields `Foo.Bar`.
+fn extract_name_from_url(url: &str) -> String {
+    // Take the last path segment and strip `.html` extension
+    let segment = url.rsplit('/').next().unwrap_or(url);
+    segment.strip_suffix(".html").unwrap_or(segment).to_string()
+}
+
+// ---------------------------------------------------------------------------
+// lean_state_search
+// ---------------------------------------------------------------------------
+
+/// Handle `lean_state_search`: get goal from LSP, then search premise-search.com.
+///
+/// 1. Opens file and gets proof goal at position via LSP
+/// 2. URL-encodes the first goal string
+/// 3. GET `https://premise-search.com/api/search?query={goal}&results={n}&rev=v4.22.0`
+///
+/// Rate limit category: `lean_state_search` (6/30s).
+pub async fn handle_state_search(
+    lsp_client: &dyn LspClient,
+    file_path: &str,
+    line: u32,
+    column: u32,
+    num_results: usize,
+    config: &SearchConfig,
+) -> Result<StateSearchResults, LeanToolError> {
+    // 1. Get goal at position
+    let goal = get_first_goal(lsp_client, file_path, line, column).await?;
+
+    // 2. Search premise-search.com
+    let client = http_client()?;
+    let url = format!("{}/api/search", config.state_search_url);
+
+    let response = client
+        .get(&url)
+        .query(&[
+            ("query", goal.as_str()),
+            ("results", &num_results.to_string()),
+            ("rev", "v4.22.0"),
+        ])
+        .send()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("StateSearch HTTP error: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(LeanToolError::Other(format!(
+            "StateSearch returned status {}",
+            response.status()
+        )));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("StateSearch JSON parse error: {e}")))?;
+
+    let items = parse_state_search_results(&resp_json);
+
+    Ok(StateSearchResults { items })
+}
+
+/// Parse state search results.
+///
+/// Response is an array of objects with a `"name"` field.
+fn parse_state_search_results(json: &Value) -> Vec<StateSearchResult> {
+    let Some(arr) = json.as_array() else {
+        return Vec::new();
+    };
+
+    arr.iter()
+        .filter_map(|entry| {
+            let name = entry.get("name")?.as_str()?.to_string();
+            Some(StateSearchResult { name })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// lean_hammer_premise
+// ---------------------------------------------------------------------------
+
+/// Handle `lean_hammer_premise`: get goal from LSP, then POST to leanpremise.net.
+///
+/// 1. Opens file and gets proof goal at position via LSP
+/// 2. POST to `http://leanpremise.net/retrieve` with
+///    `{"state": "<goal>", "new_premises": [], "k": <n>}`
+///
+/// Rate limit category: `hammer_premise` (6/30s).
+pub async fn handle_hammer_premise(
+    lsp_client: &dyn LspClient,
+    file_path: &str,
+    line: u32,
+    column: u32,
+    num_results: usize,
+    config: &SearchConfig,
+) -> Result<PremiseResults, LeanToolError> {
+    // 1. Get goal at position
+    let goal = get_first_goal(lsp_client, file_path, line, column).await?;
+
+    // 2. Post to leanpremise.net
+    let client = http_client()?;
+    let url = format!("{}/retrieve", config.hammer_premise_url);
+
+    let body = serde_json::json!({
+        "state": goal,
+        "new_premises": [],
+        "k": num_results,
+    });
+
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("HammerPremise HTTP error: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(LeanToolError::Other(format!(
+            "HammerPremise returned status {}",
+            response.status()
+        )));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .map_err(|e| LeanToolError::Other(format!("HammerPremise JSON parse error: {e}")))?;
+
+    let items = parse_premise_results(&resp_json);
+
+    Ok(PremiseResults { items })
+}
+
+/// Parse premise results.
+///
+/// Response is an array of strings (premise names).
+fn parse_premise_results(json: &Value) -> Vec<PremiseResult> {
+    let Some(arr) = json.as_array() else {
+        return Vec::new();
+    };
+
+    arr.iter()
+        .filter_map(|entry| {
+            let name = entry.as_str()?.to_string();
+            Some(PremiseResult { name })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Open a file via LSP and get the first goal at the given position.
+///
+/// Coordinates are **1-indexed** (user-facing). They are converted to
+/// 0-indexed before calling the LSP client.
+async fn get_first_goal(
+    client: &dyn LspClient,
+    file_path: &str,
+    line: u32,
+    column: u32,
+) -> Result<String, LeanToolError> {
+    // Open the file
+    client
+        .open_file(file_path)
+        .await
+        .map_err(|e| LeanToolError::LspError {
+            operation: "open_file".into(),
+            message: e.to_string(),
+        })?;
+
+    // Convert to 0-indexed
+    let lsp_line = line.saturating_sub(1);
+    let lsp_col = column.saturating_sub(1);
+
+    // Get goal
+    let goal_response = client
+        .get_goal(file_path, lsp_line, lsp_col)
+        .await
+        .map_err(|e| LeanToolError::LspError {
+            operation: "get_goal".into(),
+            message: e.to_string(),
+        })?;
+
+    let goals = extract_goals_list(goal_response.as_ref());
+
+    goals
+        .into_iter()
+        .next()
+        .ok_or(LeanToolError::NoGoals { line, column })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use serde_json::json;
+    use std::path::{Path, PathBuf};
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // -- Mock LSP client for state_search / hammer_premise ----------------
+
+    struct MockSearchLspClient {
+        project: PathBuf,
+        content: String,
+        goal_responses: Vec<((u32, u32), Option<Value>)>,
+    }
+
+    impl MockSearchLspClient {
+        fn new(content: &str) -> Self {
+            Self {
+                project: PathBuf::from("/test/project"),
+                content: content.to_string(),
+                goal_responses: Vec::new(),
+            }
+        }
+
+        fn with_goal(mut self, line: u32, col: u32, response: Option<Value>) -> Self {
+            self.goal_responses.push(((line, col), response));
+            self
+        }
+    }
+
+    #[async_trait]
+    impl LspClient for MockSearchLspClient {
+        fn project_path(&self) -> &Path {
+            &self.project
+        }
+
+        async fn open_file(
+            &self,
+            _relative_path: &str,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn open_file_force(
+            &self,
+            _relative_path: &str,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn get_file_content(
+            &self,
+            _relative_path: &str,
+        ) -> Result<String, lean_lsp_client::client::LspClientError> {
+            Ok(self.content.clone())
+        }
+
+        async fn update_file(
+            &self,
+            _relative_path: &str,
+            _changes: Vec<Value>,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn update_file_content(
+            &self,
+            _relative_path: &str,
+            _content: &str,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn close_files(
+            &self,
+            _paths: &[String],
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn get_diagnostics(
+            &self,
+            _relative_path: &str,
+            _start_line: Option<u32>,
+            _end_line: Option<u32>,
+            _inactivity_timeout: Option<f64>,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({}))
+        }
+
+        async fn get_interactive_diagnostics(
+            &self,
+            _relative_path: &str,
+            _start_line: Option<u32>,
+            _end_line: Option<u32>,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_goal(
+            &self,
+            _relative_path: &str,
+            line: u32,
+            column: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            for ((l, c), resp) in &self.goal_responses {
+                if *l == line && *c == column {
+                    return Ok(resp.clone());
+                }
+            }
+            Ok(None)
+        }
+
+        async fn get_term_goal(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(None)
+        }
+
+        async fn get_hover(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(None)
+        }
+
+        async fn get_completions(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_declarations(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_references(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+            _include_declaration: bool,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_document_symbols(
+            &self,
+            _relative_path: &str,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_code_actions(
+            &self,
+            _relative_path: &str,
+            _start_line: u32,
+            _start_col: u32,
+            _end_line: u32,
+            _end_col: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_code_action_resolve(
+            &self,
+            _action: Value,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({}))
+        }
+
+        async fn get_widgets(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_widget_source(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+            _javascript_hash: &str,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({}))
+        }
+
+        async fn shutdown(&self) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+    }
+
+    /// Build a `SearchConfig` pointing at the given mock server URL.
+    fn mock_config(server_url: &str) -> SearchConfig {
+        SearchConfig {
+            leansearch_url: server_url.to_string(),
+            loogle_url: server_url.to_string(),
+            leanfinder_url: server_url.to_string(),
+            state_search_url: server_url.to_string(),
+            hammer_premise_url: server_url.to_string(),
+        }
+    }
+
+    // =====================================================================
+    // LeanSearch tests
+    // =====================================================================
+
+    #[tokio::test]
+    async fn leansearch_returns_results() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [[
+                    {
+                        "result": {
+                            "name": ["Nat", ".", "add", "_", "comm"],
+                            "module_name": ["Init", ".", "Data", ".", "Nat"],
+                            "kind": "theorem",
+                            "type": ["forall", " (n m : Nat), n + m = m + n"]
+                        }
+                    },
+                    {
+                        "result": {
+                            "name": ["Nat", ".", "mul", "_", "comm"],
+                            "module_name": ["Init", ".", "Data", ".", "Nat"],
+                            "kind": "theorem",
+                            "type": ["forall", " (n m : Nat), n * m = m * n"]
+                        }
+                    }
+                ]]
+            })))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_leansearch("commutativity of addition", 5, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.items[0].name, "Nat.add_comm");
+        assert_eq!(result.items[0].module_name, "Init.Data.Nat");
+        assert_eq!(result.items[0].kind, Some("theorem".to_string()));
+        assert_eq!(
+            result.items[0].r#type,
+            Some("forall (n m : Nat), n + m = m + n".to_string())
+        );
+        assert_eq!(result.items[1].name, "Nat.mul_comm");
+    }
+
+    #[tokio::test]
+    async fn leansearch_handles_empty_response() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [[]]
+            })))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_leansearch("nonexistent query", 5, &config)
+            .await
+            .unwrap();
+
+        assert!(result.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn leansearch_handles_missing_results_key() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_leansearch("query", 5, &config).await.unwrap();
+
+        assert!(result.items.is_empty());
+    }
+
+    // =====================================================================
+    // Loogle tests
+    // =====================================================================
+
+    #[tokio::test]
+    async fn loogle_returns_results() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/json"))
+            .and(query_param("q", "Nat.add_comm"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "hits": [
+                    {
+                        "name": "Nat.add_comm",
+                        "type": "forall (n m : Nat), n + m = m + n",
+                        "module": "Init.Data.Nat.Lemmas"
+                    },
+                    {
+                        "name": "Nat.add_comm'",
+                        "type": "forall (n m : Nat), n + m = m + n",
+                        "module": "Init.Data.Nat.Lemmas"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_loogle_remote("Nat.add_comm", 8, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.items[0].name, "Nat.add_comm");
+        assert_eq!(result.items[0].r#type, "forall (n m : Nat), n + m = m + n");
+        assert_eq!(result.items[0].module, "Init.Data.Nat.Lemmas");
+    }
+
+    #[tokio::test]
+    async fn loogle_handles_no_hits() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "hits": []
+            })))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_loogle_remote("nonexistent", 8, &config)
+            .await
+            .unwrap();
+
+        assert!(result.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn loogle_handles_error_response() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "error": "Invalid query syntax"
+            })))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let err = handle_loogle_remote("bad query ??? !!!", 8, &config)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Loogle error"));
+        assert!(err.to_string().contains("Invalid query syntax"));
+    }
+
+    #[tokio::test]
+    async fn loogle_respects_num_results() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "hits": [
+                    {"name": "A", "type": "T", "module": "M"},
+                    {"name": "B", "type": "T", "module": "M"},
+                    {"name": "C", "type": "T", "module": "M"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_loogle_remote("query", 2, &config).await.unwrap();
+
+        assert_eq!(result.items.len(), 2);
+    }
+
+    // =====================================================================
+    // LeanFinder tests
+    // =====================================================================
+
+    #[tokio::test]
+    async fn leanfinder_filters_to_mathlib4() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "corpus": "mathlib4",
+                    "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Group/Nat.add_comm.html",
+                    "formal_statement": "theorem Nat.add_comm : forall n m, n + m = m + n",
+                    "informal_statement": "Commutativity of natural number addition"
+                },
+                {
+                    "corpus": "other_corpus",
+                    "url": "https://example.com/Other.html",
+                    "formal_statement": "def other",
+                    "informal_statement": "Not mathlib4"
+                },
+                {
+                    "corpus": "mathlib4",
+                    "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Group/Nat.mul_comm.html",
+                    "formal_statement": "theorem Nat.mul_comm : forall n m, n * m = m * n",
+                    "informal_statement": "Commutativity of natural number multiplication"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_leanfinder("commutativity", 5, &config)
+            .await
+            .unwrap();
+
+        // Only mathlib4 results should be included
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.items[0].full_name, "Nat.add_comm");
+        assert_eq!(result.items[1].full_name, "Nat.mul_comm");
+    }
+
+    #[tokio::test]
+    async fn leanfinder_extracts_names_from_urls() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "corpus": "mathlib4",
+                    "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Basic/IsOpen.html",
+                    "formal_statement": "def IsOpen",
+                    "informal_statement": "An open set"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_leanfinder("open set", 5, &config).await.unwrap();
+
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].full_name, "IsOpen");
+        assert_eq!(result.items[0].formal_statement, "def IsOpen");
+        assert_eq!(result.items[0].informal_statement, "An open set");
+    }
+
+    #[tokio::test]
+    async fn leanfinder_handles_empty_response() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let result = handle_leanfinder("nothing", 5, &config).await.unwrap();
+
+        assert!(result.items.is_empty());
+    }
+
+    // =====================================================================
+    // State Search tests
+    // =====================================================================
+
+    #[tokio::test]
+    async fn state_search_gets_goal_then_searches() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/search"))
+            .and(query_param("query", "a : Nat |- a = a"))
+            .and(query_param("rev", "v4.22.0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {"name": "rfl"},
+                {"name": "Eq.refl"}
+            ])))
+            .mount(&server)
+            .await;
+
+        // Mock LSP: line 2, col 3 -> 0-indexed (1, 2) -> goal response
+        let lsp = MockSearchLspClient::new("theorem foo : Nat := by\n  exact h").with_goal(
+            1,
+            2,
+            Some(json!({"goals": ["a : Nat |- a = a"]})),
+        );
+
+        let config = mock_config(&server.uri());
+        let result = handle_state_search(&lsp, "Main.lean", 2, 3, 5, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.items[0].name, "rfl");
+        assert_eq!(result.items[1].name, "Eq.refl");
+    }
+
+    #[tokio::test]
+    async fn state_search_no_goals_returns_error() {
+        let server = MockServer::start().await;
+        let lsp = MockSearchLspClient::new("import Mathlib");
+
+        let config = mock_config(&server.uri());
+        let err = handle_state_search(&lsp, "Main.lean", 1, 1, 5, &config)
+            .await
+            .unwrap_err();
+
+        match err {
+            LeanToolError::NoGoals { line, column } => {
+                assert_eq!(line, 1);
+                assert_eq!(column, 1);
+            }
+            other => panic!("expected NoGoals, got: {other}"),
+        }
+    }
+
+    // =====================================================================
+    // Hammer Premise tests
+    // =====================================================================
+
+    #[tokio::test]
+    async fn hammer_premise_gets_goal_then_retrieves() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/retrieve"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                "Nat.add_comm",
+                "Nat.add_assoc",
+                "Nat.zero_add"
+            ])))
+            .mount(&server)
+            .await;
+
+        let lsp = MockSearchLspClient::new("theorem foo : Nat := by\n  simp").with_goal(
+            1,
+            2,
+            Some(json!({"goals": ["n m : Nat |- n + m = m + n"]})),
+        );
+
+        let config = mock_config(&server.uri());
+        let result = handle_hammer_premise(&lsp, "Main.lean", 2, 3, 32, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(result.items.len(), 3);
+        assert_eq!(result.items[0].name, "Nat.add_comm");
+        assert_eq!(result.items[1].name, "Nat.add_assoc");
+        assert_eq!(result.items[2].name, "Nat.zero_add");
+    }
+
+    #[tokio::test]
+    async fn hammer_premise_no_goals_returns_error() {
+        let server = MockServer::start().await;
+        let lsp = MockSearchLspClient::new("import Mathlib");
+
+        let config = mock_config(&server.uri());
+        let err = handle_hammer_premise(&lsp, "Main.lean", 1, 1, 32, &config)
+            .await
+            .unwrap_err();
+
+        match err {
+            LeanToolError::NoGoals { line, column } => {
+                assert_eq!(line, 1);
+                assert_eq!(column, 1);
+            }
+            other => panic!("expected NoGoals, got: {other}"),
+        }
+    }
+
+    // =====================================================================
+    // Error cases
+    // =====================================================================
+
+    #[tokio::test]
+    async fn leansearch_http_error_status() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/search"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let err = handle_leansearch("query", 5, &config).await.unwrap_err();
+
+        assert!(err.to_string().contains("status"));
+    }
+
+    #[tokio::test]
+    async fn loogle_http_error_status() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/json"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let err = handle_loogle_remote("query", 8, &config).await.unwrap_err();
+
+        assert!(err.to_string().contains("status"));
+    }
+
+    #[tokio::test]
+    async fn leanfinder_http_error_status() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(502))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let err = handle_leanfinder("query", 5, &config).await.unwrap_err();
+
+        assert!(err.to_string().contains("status"));
+    }
+
+    #[tokio::test]
+    async fn leansearch_invalid_json_response() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let config = mock_config(&server.uri());
+        let err = handle_leansearch("query", 5, &config).await.unwrap_err();
+
+        assert!(err.to_string().contains("JSON parse error"));
+    }
+
+    #[tokio::test]
+    async fn state_search_http_error_status() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/search"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let lsp = MockSearchLspClient::new("theorem foo := by\n  simp").with_goal(
+            1,
+            2,
+            Some(json!({"goals": ["some goal"]})),
+        );
+
+        let config = mock_config(&server.uri());
+        let err = handle_state_search(&lsp, "Main.lean", 2, 3, 5, &config)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("status"));
+    }
+
+    #[tokio::test]
+    async fn hammer_premise_http_error_status() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/retrieve"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let lsp = MockSearchLspClient::new("theorem foo := by\n  simp").with_goal(
+            1,
+            2,
+            Some(json!({"goals": ["some goal"]})),
+        );
+
+        let config = mock_config(&server.uri());
+        let err = handle_hammer_premise(&lsp, "Main.lean", 2, 3, 32, &config)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("status"));
+    }
+
+    // =====================================================================
+    // Unit tests for parsing helpers
+    // =====================================================================
+
+    #[test]
+    fn join_string_array_from_array() {
+        let v = json!(["Nat", ".", "add", "_", "comm"]);
+        assert_eq!(join_string_array(&v), "Nat.add_comm");
+    }
+
+    #[test]
+    fn join_string_array_from_string() {
+        let v = json!("Nat.add_comm");
+        assert_eq!(join_string_array(&v), "Nat.add_comm");
+    }
+
+    #[test]
+    fn join_string_array_from_non_string() {
+        let v = json!(42);
+        assert_eq!(join_string_array(&v), "");
+    }
+
+    #[test]
+    fn extract_name_from_url_with_html_extension() {
+        assert_eq!(
+            extract_name_from_url(
+                "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Nat.add_comm.html"
+            ),
+            "Nat.add_comm"
+        );
+    }
+
+    #[test]
+    fn extract_name_from_url_no_html_extension() {
+        assert_eq!(
+            extract_name_from_url("https://example.com/SomeName"),
+            "SomeName"
+        );
+    }
+
+    #[test]
+    fn parse_leansearch_empty_results() {
+        let json = json!({"results": [[]]});
+        assert!(parse_leansearch_results(&json).is_empty());
+    }
+
+    #[test]
+    fn parse_loogle_empty_hits() {
+        let json = json!({"hits": []});
+        assert!(parse_loogle_results(&json, 10).is_empty());
+    }
+
+    #[test]
+    fn parse_state_search_non_array() {
+        let json = json!({"error": "something"});
+        assert!(parse_state_search_results(&json).is_empty());
+    }
+
+    #[test]
+    fn parse_premise_results_with_strings() {
+        let json = json!(["foo", "bar", "baz"]);
+        let results = parse_premise_results(&json);
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].name, "foo");
+        assert_eq!(results[2].name, "baz");
+    }
+
+    #[test]
+    fn parse_premise_results_empty_array() {
+        let json = json!([]);
+        assert!(parse_premise_results(&json).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Implement five HTTP-based search tool handlers in `crates/lean-mcp-server/src/tools/search.rs`:
  - `handle_leansearch` -- POST to leansearch.net for natural language to Mathlib search
  - `handle_loogle_remote` -- GET to loogle.lean-lang.org for type-pattern search
  - `handle_leanfinder` -- POST to HuggingFace endpoint with mathlib4 corpus filtering
  - `handle_state_search` -- get LSP goal at position, then GET premise-search.com
  - `handle_hammer_premise` -- get LSP goal at position, then POST leanpremise.net/retrieve
- All handlers accept configurable base URLs via `SearchConfig` (env vars or direct) for testability with wiremock
- Add `reqwest` (runtime) and `wiremock` (dev) dependencies to lean-mcp-server
- 26 tests using `wiremock::MockServer` covering happy paths, empty responses, HTTP errors, invalid JSON, no-goals errors, URL name extraction, and parsing helpers

Closes #31, #32, #33, #34, #35

## Test plan
- [x] All 26 search tests pass with `cargo test --all`
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean