### PR TITLE
feat: add criterion benchmark suite

### DIFF
--- a/crates/lean-lsp-client/Cargo.toml
+++ b/crates/lean-lsp-client/Cargo.toml
@@ -17,7 +17,12 @@ tracing = "0.1"
 async-trait = "0.1"
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 tokio-test = "0.4"
 mockall = "0.14"
 tempfile = "3"
 pretty_assertions = "1"
+
+[[bench]]
+name = "transport_bench"
+harness = false

--- a/crates/lean-lsp-client/benches/transport_bench.rs
+++ b/crates/lean-lsp-client/benches/transport_bench.rs
@@ -1,0 +1,231 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lean_lsp_client::jsonrpc::{Message, Notification, Request, Response, ResponseError};
+use lean_lsp_client::transport::{read_message, write_message};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// JSON-RPC serialization
+// ---------------------------------------------------------------------------
+
+fn bench_request_serialize(c: &mut Criterion) {
+    let req = Request::new(
+        1,
+        "textDocument/hover",
+        Some(json!({
+            "textDocument": {"uri": "file:///tmp/Test.lean"},
+            "position": {"line": 10, "character": 5}
+        })),
+    );
+    c.bench_function("jsonrpc_request_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&req)).unwrap())
+    });
+}
+
+fn bench_request_deserialize(c: &mut Criterion) {
+    let json_str = r#"{"jsonrpc":"2.0","id":1,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///tmp/Test.lean"},"position":{"line":10,"character":5}}}"#;
+    c.bench_function("jsonrpc_request_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<Request>(black_box(json_str)).unwrap())
+    });
+}
+
+fn bench_response_serialize(c: &mut Criterion) {
+    let resp = Response {
+        jsonrpc: "2.0".to_string(),
+        id: Some(1),
+        result: Some(json!({
+            "contents": {"kind": "markdown", "value": "```lean\nNat.add : Nat → Nat → Nat\n```"}
+        })),
+        error: None,
+    };
+    c.bench_function("jsonrpc_response_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&resp)).unwrap())
+    });
+}
+
+fn bench_response_deserialize(c: &mut Criterion) {
+    let json_str = r#"{"jsonrpc":"2.0","id":1,"result":{"contents":{"kind":"markdown","value":"```lean\nNat.add : Nat → Nat → Nat\n```"}}}"#;
+    c.bench_function("jsonrpc_response_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<Response>(black_box(json_str)).unwrap())
+    });
+}
+
+fn bench_response_error_serialize(c: &mut Criterion) {
+    let resp = Response {
+        jsonrpc: "2.0".to_string(),
+        id: Some(1),
+        result: None,
+        error: Some(ResponseError {
+            code: -32601,
+            message: "Method not found".to_string(),
+            data: Some(json!({"method": "unknown/method"})),
+        }),
+    };
+    c.bench_function("jsonrpc_response_error_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&resp)).unwrap())
+    });
+}
+
+fn bench_notification_serialize(c: &mut Criterion) {
+    let notif = Notification::new(
+        "textDocument/didOpen",
+        Some(json!({
+            "textDocument": {
+                "uri": "file:///tmp/Test.lean",
+                "languageId": "lean4",
+                "version": 1,
+                "text": "import Mathlib.Tactic\n\ntheorem foo : 1 + 1 = 2 := by omega"
+            }
+        })),
+    );
+    c.bench_function("jsonrpc_notification_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&notif)).unwrap())
+    });
+}
+
+fn bench_notification_deserialize(c: &mut Criterion) {
+    let json_str = r#"{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///tmp/Test.lean","languageId":"lean4","version":1,"text":"import Mathlib.Tactic\n\ntheorem foo : 1 + 1 = 2 := by omega"}}}"#;
+    c.bench_function("jsonrpc_notification_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<Notification>(black_box(json_str)).unwrap())
+    });
+}
+
+fn bench_message_from_value_request(c: &mut Criterion) {
+    let value = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}});
+    c.bench_function("jsonrpc_message_from_value_request", |b| {
+        b.iter(|| Message::from_value(black_box(value.clone())).unwrap())
+    });
+}
+
+fn bench_message_from_value_response(c: &mut Criterion) {
+    let value = json!({"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}});
+    c.bench_function("jsonrpc_message_from_value_response", |b| {
+        b.iter(|| Message::from_value(black_box(value.clone())).unwrap())
+    });
+}
+
+fn bench_message_from_value_notification(c: &mut Criterion) {
+    let value = json!({"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///tmp/Test.lean","diagnostics":[]}});
+    c.bench_function("jsonrpc_message_from_value_notification", |b| {
+        b.iter(|| Message::from_value(black_box(value.clone())).unwrap())
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Content-Length framing
+// ---------------------------------------------------------------------------
+
+fn bench_write_message(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let msg = json!({"jsonrpc":"2.0","id":1,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///tmp/Test.lean"},"position":{"line":10,"character":5}}});
+
+    c.bench_function("transport_write_message", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut buf = Vec::with_capacity(512);
+                write_message(&mut buf, black_box(&msg)).await.unwrap();
+                buf
+            })
+        })
+    });
+}
+
+fn bench_read_message(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let msg = json!({"jsonrpc":"2.0","id":1,"result":{"capabilities":{"hoverProvider":true}}});
+    let body = serde_json::to_string(&msg).unwrap();
+    let frame = format!("Content-Length: {}\r\n\r\n{}", body.len(), body);
+    let frame_bytes = frame.into_bytes();
+
+    c.bench_function("transport_read_message", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut reader = tokio::io::BufReader::new(black_box(frame_bytes.as_slice()));
+                read_message(&mut reader).await.unwrap()
+            })
+        })
+    });
+}
+
+fn bench_write_read_roundtrip(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let msg = json!({"jsonrpc":"2.0","id":42,"method":"textDocument/completion","params":{"textDocument":{"uri":"file:///tmp/Test.lean"},"position":{"line":5,"character":10}}});
+
+    c.bench_function("transport_write_read_roundtrip", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut buf = Vec::with_capacity(512);
+                write_message(&mut buf, black_box(&msg)).await.unwrap();
+                let mut reader = tokio::io::BufReader::new(buf.as_slice());
+                read_message(&mut reader).await.unwrap()
+            })
+        })
+    });
+}
+
+fn bench_write_message_large(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    // Simulate a large didOpen notification with substantial file content.
+    let large_text = "import Mathlib.Tactic\n".repeat(200);
+    let msg = json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///tmp/LargeFile.lean",
+                "languageId": "lean4",
+                "version": 1,
+                "text": large_text
+            }
+        }
+    });
+
+    c.bench_function("transport_write_message_large", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut buf = Vec::with_capacity(8192);
+                write_message(&mut buf, black_box(&msg)).await.unwrap();
+                buf
+            })
+        })
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Groups
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    jsonrpc_benches,
+    bench_request_serialize,
+    bench_request_deserialize,
+    bench_response_serialize,
+    bench_response_deserialize,
+    bench_response_error_serialize,
+    bench_notification_serialize,
+    bench_notification_deserialize,
+    bench_message_from_value_request,
+    bench_message_from_value_response,
+    bench_message_from_value_notification,
+);
+
+criterion_group!(
+    transport_benches,
+    bench_write_message,
+    bench_read_message,
+    bench_write_read_roundtrip,
+    bench_write_message_large,
+);
+
+criterion_main!(jsonrpc_benches, transport_benches);

--- a/crates/lean-mcp-core/Cargo.toml
+++ b/crates/lean-mcp-core/Cargo.toml
@@ -21,9 +21,14 @@ uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 tokio-test = "0.4"
 mockall = "0.14"
 wiremock = "0.6"
 tempfile = "3"
 proptest = "1"
 pretty_assertions = "1"
+
+[[bench]]
+name = "core_bench"
+harness = false

--- a/crates/lean-mcp-core/benches/core_bench.rs
+++ b/crates/lean-mcp-core/benches/core_bench.rs
@@ -1,0 +1,371 @@
+use std::collections::HashMap;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lean_mcp_core::models::{
+    BuildResult, CodeAction, CodeActionEdit, CodeActionsResult, CompletionItem, CompletionsResult,
+    DiagnosticMessage, DiagnosticsResult, FileOutline, GoalState, HoverInfo, LineProfile,
+    OutlineEntry, ProofProfileResult, VerifyResult,
+};
+use lean_mcp_core::rate_limit::RateLimiter;
+
+// ---------------------------------------------------------------------------
+// Model serialization round-trips
+// ---------------------------------------------------------------------------
+
+fn bench_goal_state_roundtrip(c: &mut Criterion) {
+    let gs = GoalState {
+        line_context: "exact Nat.succ_pos n".into(),
+        goals: Some(vec![
+            "0 < Nat.succ n".into(),
+            "∀ (m : Nat), m < n → 0 < m".into(),
+        ]),
+        goals_before: None,
+        goals_after: None,
+    };
+    let json = serde_json::to_string(&gs).unwrap();
+
+    c.bench_function("model_goal_state_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&gs)).unwrap())
+    });
+    c.bench_function("model_goal_state_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<GoalState>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_diagnostics_result_roundtrip(c: &mut Criterion) {
+    let dr = DiagnosticsResult {
+        success: false,
+        items: vec![
+            DiagnosticMessage {
+                severity: "error".into(),
+                message: "unknown identifier 'foo'".into(),
+                line: 10,
+                column: 5,
+            },
+            DiagnosticMessage {
+                severity: "warning".into(),
+                message: "unused variable 'x'".into(),
+                line: 15,
+                column: 3,
+            },
+            DiagnosticMessage {
+                severity: "info".into(),
+                message: "declaration uses sorry".into(),
+                line: 20,
+                column: 1,
+            },
+        ],
+        failed_dependencies: vec!["Mathlib.Tactic".into(), "Mathlib.Data.Nat.Basic".into()],
+    };
+    let json = serde_json::to_string(&dr).unwrap();
+
+    c.bench_function("model_diagnostics_result_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&dr)).unwrap())
+    });
+    c.bench_function("model_diagnostics_result_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<DiagnosticsResult>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_hover_info_roundtrip(c: &mut Criterion) {
+    let hi = HoverInfo {
+        symbol: "Nat.add".into(),
+        info: "Nat → Nat → Nat\n\nAddition of natural numbers.".into(),
+        diagnostics: vec![DiagnosticMessage {
+            severity: "info".into(),
+            message: "type mismatch".into(),
+            line: 5,
+            column: 10,
+        }],
+    };
+    let json = serde_json::to_string(&hi).unwrap();
+
+    c.bench_function("model_hover_info_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&hi)).unwrap())
+    });
+    c.bench_function("model_hover_info_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<HoverInfo>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_completions_result_roundtrip(c: &mut Criterion) {
+    let cr = CompletionsResult {
+        items: (0..20)
+            .map(|i| CompletionItem {
+                label: format!("Nat.add_comm_{i}"),
+                kind: Some("Function".into()),
+                detail: Some(format!("∀ (n m : Nat), n + m = m + n (variant {i})")),
+            })
+            .collect(),
+    };
+    let json = serde_json::to_string(&cr).unwrap();
+
+    c.bench_function("model_completions_result_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&cr)).unwrap())
+    });
+    c.bench_function("model_completions_result_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<CompletionsResult>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_file_outline_roundtrip(c: &mut Criterion) {
+    let fo = FileOutline {
+        imports: vec![
+            "Mathlib.Tactic".into(),
+            "Mathlib.Data.Nat.Basic".into(),
+            "Mathlib.Order.Lattice".into(),
+        ],
+        declarations: vec![
+            OutlineEntry {
+                name: "MyNamespace".into(),
+                kind: "Ns".into(),
+                start_line: 5,
+                end_line: 100,
+                type_signature: None,
+                children: vec![
+                    OutlineEntry {
+                        name: "myTheorem".into(),
+                        kind: "Thm".into(),
+                        start_line: 10,
+                        end_line: 20,
+                        type_signature: Some("∀ (n : Nat), n + 0 = n".into()),
+                        children: vec![],
+                    },
+                    OutlineEntry {
+                        name: "myDef".into(),
+                        kind: "Def".into(),
+                        start_line: 25,
+                        end_line: 35,
+                        type_signature: Some("Nat → Nat".into()),
+                        children: vec![],
+                    },
+                ],
+            },
+            OutlineEntry {
+                name: "anotherDef".into(),
+                kind: "Def".into(),
+                start_line: 105,
+                end_line: 110,
+                type_signature: Some("String → Bool".into()),
+                children: vec![],
+            },
+        ],
+        total_declarations: Some(3),
+    };
+    let json = serde_json::to_string(&fo).unwrap();
+
+    c.bench_function("model_file_outline_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&fo)).unwrap())
+    });
+    c.bench_function("model_file_outline_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<FileOutline>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_code_actions_result_roundtrip(c: &mut Criterion) {
+    let car = CodeActionsResult {
+        actions: vec![
+            CodeAction {
+                title: "Try this: simp only [Nat.add_comm, Nat.add_assoc]".into(),
+                is_preferred: true,
+                edits: vec![CodeActionEdit {
+                    new_text: "simp only [Nat.add_comm, Nat.add_assoc]".into(),
+                    start_line: 5,
+                    start_column: 3,
+                    end_line: 5,
+                    end_column: 8,
+                }],
+            },
+            CodeAction {
+                title: "Try this: omega".into(),
+                is_preferred: false,
+                edits: vec![CodeActionEdit {
+                    new_text: "omega".into(),
+                    start_line: 5,
+                    start_column: 3,
+                    end_line: 5,
+                    end_column: 8,
+                }],
+            },
+        ],
+    };
+    let json = serde_json::to_string(&car).unwrap();
+
+    c.bench_function("model_code_actions_result_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&car)).unwrap())
+    });
+    c.bench_function("model_code_actions_result_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<CodeActionsResult>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_proof_profile_result_roundtrip(c: &mut Criterion) {
+    let mut categories = HashMap::new();
+    categories.insert("elaboration".into(), 42.5);
+    categories.insert("type_checking".into(), 13.2);
+    categories.insert("tactic".into(), 28.8);
+    let ppr = ProofProfileResult {
+        ms: 84.5,
+        lines: vec![
+            LineProfile {
+                line: 10,
+                ms: 42.5,
+                text: "  exact h".into(),
+            },
+            LineProfile {
+                line: 15,
+                ms: 28.8,
+                text: "  simp [Nat.add_comm]".into(),
+            },
+            LineProfile {
+                line: 20,
+                ms: 13.2,
+                text: "  ring".into(),
+            },
+        ],
+        categories,
+    };
+    let json = serde_json::to_string(&ppr).unwrap();
+
+    c.bench_function("model_proof_profile_result_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&ppr)).unwrap())
+    });
+    c.bench_function("model_proof_profile_result_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<ProofProfileResult>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_verify_result_roundtrip(c: &mut Criterion) {
+    let vr = VerifyResult {
+        axioms: vec![
+            "propext".into(),
+            "Classical.choice".into(),
+            "Quot.sound".into(),
+        ],
+        warnings: vec![],
+    };
+    let json = serde_json::to_string(&vr).unwrap();
+
+    c.bench_function("model_verify_result_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&vr)).unwrap())
+    });
+    c.bench_function("model_verify_result_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<VerifyResult>(black_box(&json)).unwrap())
+    });
+}
+
+fn bench_build_result_roundtrip(c: &mut Criterion) {
+    let br = BuildResult {
+        success: true,
+        output: "Build completed successfully.\nCompiled 42 modules.".into(),
+        errors: vec![],
+    };
+    let json = serde_json::to_string(&br).unwrap();
+
+    c.bench_function("model_build_result_serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&br)).unwrap())
+    });
+    c.bench_function("model_build_result_deserialize", |b| {
+        b.iter(|| serde_json::from_str::<BuildResult>(black_box(&json)).unwrap())
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiter throughput
+// ---------------------------------------------------------------------------
+
+fn bench_rate_limiter_under_limit(c: &mut Criterion) {
+    c.bench_function("rate_limiter_check_and_record_under_limit", |b| {
+        b.iter(|| {
+            let mut rl = RateLimiter::new();
+            for _ in 0..3 {
+                rl.check_and_record(black_box("leansearch"), 3, 30).unwrap();
+            }
+        })
+    });
+}
+
+fn bench_rate_limiter_at_limit(c: &mut Criterion) {
+    c.bench_function("rate_limiter_check_and_record_at_limit", |b| {
+        b.iter(|| {
+            let mut rl = RateLimiter::new();
+            for _ in 0..10 {
+                rl.check_and_record(black_box("leanfinder"), 10, 30)
+                    .unwrap();
+            }
+            // This call should fail.
+            let _ = rl.check_and_record(black_box("leanfinder"), 10, 30);
+        })
+    });
+}
+
+fn bench_rate_limiter_multiple_categories(c: &mut Criterion) {
+    let categories = [
+        "leansearch",
+        "loogle",
+        "leanfinder",
+        "state_search",
+        "hammer",
+    ];
+    c.bench_function("rate_limiter_multiple_categories", |b| {
+        b.iter(|| {
+            let mut rl = RateLimiter::new();
+            for cat in &categories {
+                for _ in 0..3 {
+                    rl.check_and_record(black_box(cat), 6, 30).unwrap();
+                }
+            }
+        })
+    });
+}
+
+fn bench_rate_limiter_window_pruning(c: &mut Criterion) {
+    use std::time::{Duration, Instant};
+
+    c.bench_function("rate_limiter_window_pruning", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let mut rl = RateLimiter::new();
+                // Fill via check_and_record then
+                // age-out by using a very short window.
+                for _ in 0..10 {
+                    rl.check_and_record("bench", 100, 3600).unwrap();
+                }
+                // Now time the pruning call with a 0-second window
+                // (all 10 timestamps will be pruned).
+                let start = Instant::now();
+                let _ = rl.check_and_record(black_box("bench"), 100, 0);
+                total += start.elapsed();
+            }
+            total
+        })
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Groups
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    model_benches,
+    bench_goal_state_roundtrip,
+    bench_diagnostics_result_roundtrip,
+    bench_hover_info_roundtrip,
+    bench_completions_result_roundtrip,
+    bench_file_outline_roundtrip,
+    bench_code_actions_result_roundtrip,
+    bench_proof_profile_result_roundtrip,
+    bench_verify_result_roundtrip,
+    bench_build_result_roundtrip,
+);
+
+criterion_group!(
+    rate_limiter_benches,
+    bench_rate_limiter_under_limit,
+    bench_rate_limiter_at_limit,
+    bench_rate_limiter_multiple_categories,
+    bench_rate_limiter_window_pruning,
+);
+
+criterion_main!(model_benches, rate_limiter_benches);


### PR DESCRIPTION
## Summary
- Add per-crate criterion benchmarks for performance regression tracking
- **lean-lsp-client**: JSON-RPC serialization/deserialization, `Message::from_value` dispatch, Content-Length framing read/write, roundtrip and large message benchmarks
- **lean-mcp-core**: Model serialization round-trips (9 model types), `RateLimiter::check_and_record` throughput (under/at limit, multi-category, window pruning)

## Test plan
- [x] `cargo test --all` — 269 tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo bench --no-run` — benchmarks compile in release mode
- [ ] CI passes

Closes #37