### PR TITLE
ci: add release workflow for cross-platform binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  BINARY_NAME: rust-lean-mcp
+
+jobs:
+  # -------------------------------------------------------------------------
+  # Run full CI checks before building release artifacts
+  # -------------------------------------------------------------------------
+  ci:
+    name: CI checks
+    uses: ./.github/workflows/ci.yml
+
+  # -------------------------------------------------------------------------
+  # Build release binaries for each target
+  # -------------------------------------------------------------------------
+  build:
+    name: Build (${{ matrix.target }})
+    needs: ci
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: tar.gz
+            cross: true
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            archive: tar.gz
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      # Install cross for Linux cross-compilation
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      # Build the release binary
+      - name: Build
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      # Package the binary into a tarball
+      - name: Package
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          staging="${BINARY_NAME}-${tag}-${{ matrix.target }}"
+          mkdir -p "${staging}"
+
+          cp "target/${{ matrix.target }}/release/${BINARY_NAME}" "${staging}/"
+          cp README.md LICENSE "${staging}/" 2>/dev/null || true
+
+          tar czf "${staging}.tar.gz" "${staging}"
+          echo "ASSET=${staging}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
+          path: ${{ env.ASSET }}
+
+  # -------------------------------------------------------------------------
+  # Create GitHub Release with all binaries
+  # -------------------------------------------------------------------------
+  release:
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # -------------------------------------------------------------------------
+  # Publish to crates.io (optional, requires CARGO_REGISTRY_TOKEN secret)
+  # -------------------------------------------------------------------------
+  publish:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    if: vars.PUBLISH_CRATES == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crates
+        run: |
+          # Publish in dependency order with a delay between crates
+          cargo publish -p lean-lsp-client --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+          sleep 30
+          cargo publish -p lean-mcp-core --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+          sleep 30
+          cargo publish -p lean-mcp-server --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` triggered on version tags (`v*`)
- Runs full CI checks first via reusable workflow call (added `workflow_call` trigger to `ci.yml`)
- Builds release binaries for 4 targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`
- Uses `cross` for Linux aarch64 cross-compilation, native runners for everything else
- Creates GitHub Release with tarballed binaries via `softprops/action-gh-release@v2`
- Optional crates.io publishing (gated on `PUBLISH_CRATES` repository variable + `CARGO_REGISTRY_TOKEN` secret)

## Test plan
- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(..."`)
- [x] `cargo test --all` — all tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] CI passes on PR
- [ ] Verify workflow triggers correctly on a `v*` tag push (post-merge)

Closes #38