### PR TITLE
feat: add lean_goals_batch tool handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +226,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -287,6 +326,73 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -374,6 +480,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -617,6 +729,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -939,10 +1062,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -971,6 +1114,7 @@ name = "lean-lsp-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "criterion",
  "lsp-types",
  "mockall",
  "pretty_assertions",
@@ -989,6 +1133,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "clap",
+ "criterion",
  "mockall",
  "pretty_assertions",
  "proptest",
@@ -1013,6 +1158,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "clap",
+ "futures",
  "lean-lsp-client",
  "lean-mcp-core",
  "predicates",
@@ -1210,6 +1356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,6 +1457,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1520,6 +1700,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1750,6 +1950,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2074,6 +2283,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2583,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,6 +2745,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/lean-mcp-core/src/models.rs
+++ b/crates/lean-mcp-core/src/models.rs
@@ -455,6 +455,43 @@ pub struct CodeActionsResult {
 }
 
 // ---------------------------------------------------------------------------
+// Batch goals
+// ---------------------------------------------------------------------------
+
+/// A single position for a batch goal query.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchGoalPosition {
+    /// Relative path to the Lean file.
+    pub file_path: String,
+    /// Line number (1-indexed).
+    pub line: u32,
+    /// Column number (1-indexed). If omitted, returns goals before/after.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<u32>,
+}
+
+/// Result for a single position in a batch goal query.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchGoalEntry {
+    /// The position that was queried.
+    pub position: BatchGoalPosition,
+    /// The goal state if the query succeeded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<GoalState>,
+    /// Error message if the query failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of querying goals at multiple positions concurrently.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchGoalResult {
+    /// Results for each queried position (same order as input).
+    #[serde(default)]
+    pub items: Vec<BatchGoalEntry>,
+}
+
+// ---------------------------------------------------------------------------
 // Verification
 // ---------------------------------------------------------------------------
 
@@ -769,6 +806,9 @@ mod tests {
         assert_send_sync::<CodeActionsResult>();
         assert_send_sync::<SourceWarning>();
         assert_send_sync::<VerifyResult>();
+        assert_send_sync::<BatchGoalPosition>();
+        assert_send_sync::<BatchGoalEntry>();
+        assert_send_sync::<BatchGoalResult>();
     }
 
     // -- Widget types with serde_json::Value --
@@ -808,5 +848,94 @@ mod tests {
         assert_eq!(entry2.children.len(), 1);
         assert_eq!(entry2.children[0].name, "myTheorem");
         assert_eq!(entry2.children[0].type_signature, Some("Nat -> Nat".into()));
+    }
+
+    // -- BatchGoal types --
+
+    #[test]
+    fn round_trip_batch_goal_position() {
+        let pos = BatchGoalPosition {
+            file_path: "Main.lean".into(),
+            line: 5,
+            column: Some(3),
+        };
+        let json = serde_json::to_string(&pos).unwrap();
+        let pos2: BatchGoalPosition = serde_json::from_str(&json).unwrap();
+        assert_eq!(pos2.file_path, "Main.lean");
+        assert_eq!(pos2.line, 5);
+        assert_eq!(pos2.column, Some(3));
+    }
+
+    #[test]
+    fn batch_goal_position_omits_none_column() {
+        let pos = BatchGoalPosition {
+            file_path: "Main.lean".into(),
+            line: 1,
+            column: None,
+        };
+        let v: Value = serde_json::to_value(&pos).unwrap();
+        assert!(!v.as_object().unwrap().contains_key("column"));
+    }
+
+    #[test]
+    fn round_trip_batch_goal_entry_success() {
+        let entry = BatchGoalEntry {
+            position: BatchGoalPosition {
+                file_path: "Main.lean".into(),
+                line: 2,
+                column: Some(3),
+            },
+            result: Some(GoalState {
+                line_context: "  exact h".into(),
+                goals: Some(vec!["⊢ True".into()]),
+                goals_before: None,
+                goals_after: None,
+            }),
+            error: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let entry2: BatchGoalEntry = serde_json::from_str(&json).unwrap();
+        assert!(entry2.result.is_some());
+        assert!(entry2.error.is_none());
+    }
+
+    #[test]
+    fn round_trip_batch_goal_entry_error() {
+        let entry = BatchGoalEntry {
+            position: BatchGoalPosition {
+                file_path: "Bad.lean".into(),
+                line: 99,
+                column: Some(1),
+            },
+            result: None,
+            error: Some("Line 99 out of range".into()),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let entry2: BatchGoalEntry = serde_json::from_str(&json).unwrap();
+        assert!(entry2.result.is_none());
+        assert_eq!(entry2.error.as_deref(), Some("Line 99 out of range"));
+    }
+
+    #[test]
+    fn round_trip_batch_goal_result() {
+        let result = BatchGoalResult {
+            items: vec![BatchGoalEntry {
+                position: BatchGoalPosition {
+                    file_path: "Main.lean".into(),
+                    line: 1,
+                    column: Some(1),
+                },
+                result: Some(GoalState {
+                    line_context: "exact h".into(),
+                    goals: Some(vec![]),
+                    goals_before: None,
+                    goals_after: None,
+                }),
+                error: None,
+            }],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let result2: BatchGoalResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result2.items.len(), 1);
     }
 }

--- a/crates/lean-mcp-server/Cargo.toml
+++ b/crates/lean-mcp-server/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive", "env"] }
+futures = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/crates/lean-mcp-server/src/tools/batch_goals.rs
+++ b/crates/lean-mcp-server/src/tools/batch_goals.rs
@@ -1,0 +1,685 @@
+//! Tool handler for `lean_goals_batch`.
+//!
+//! Queries goal states at multiple positions concurrently, returning partial
+//! results when individual positions fail. Opens each unique file once before
+//! dispatching concurrent goal queries.
+
+use std::collections::HashSet;
+
+use lean_lsp_client::client::LspClient;
+use lean_mcp_core::error::LeanToolError;
+use lean_mcp_core::models::{BatchGoalEntry, BatchGoalPosition, BatchGoalResult, GoalState};
+use lean_mcp_core::utils::extract_goals_list;
+
+/// Query a single position's goal state.
+///
+/// Returns `Ok(GoalState)` on success or `Err(message)` on failure.
+/// This never propagates errors — failures are captured as strings for
+/// partial-result semantics.
+async fn query_single_goal(
+    client: &dyn LspClient,
+    file_path: &str,
+    line: u32,
+    column: Option<u32>,
+    content: &str,
+) -> Result<GoalState, String> {
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Validate line range (1-indexed).
+    if line == 0 || line as usize > lines.len() {
+        return Err(format!(
+            "Line {line} out of range (file has {} lines)",
+            lines.len()
+        ));
+    }
+
+    let line_text = lines[(line - 1) as usize];
+    let lsp_line = line - 1; // convert to 0-indexed
+
+    match column {
+        Some(col) => {
+            let line_len = line_text.len();
+            if col == 0 || col as usize > line_len + 1 {
+                return Err(format!(
+                    "Column {col} out of range (line has {line_len} characters)"
+                ));
+            }
+
+            let lsp_col = col - 1;
+            let goal_response = client
+                .get_goal(file_path, lsp_line, lsp_col)
+                .await
+                .map_err(|e| format!("LSP error: {e}"))?;
+
+            let goals = extract_goals_list(goal_response.as_ref());
+
+            Ok(GoalState {
+                line_context: line_text.to_string(),
+                goals: Some(goals),
+                goals_before: None,
+                goals_after: None,
+            })
+        }
+        None => {
+            let first_non_ws = line_text.find(|c: char| !c.is_whitespace()).unwrap_or(0) as u32;
+            let end_col = line_text.trim_end().len() as u32;
+
+            let (before_response, after_response) = tokio::join!(
+                client.get_goal(file_path, lsp_line, first_non_ws),
+                client.get_goal(file_path, lsp_line, end_col),
+            );
+
+            let goals_before = extract_goals_list(
+                before_response
+                    .map_err(|e| format!("LSP error: {e}"))?
+                    .as_ref(),
+            );
+            let goals_after = extract_goals_list(
+                after_response
+                    .map_err(|e| format!("LSP error: {e}"))?
+                    .as_ref(),
+            );
+
+            Ok(GoalState {
+                line_context: line_text.to_string(),
+                goals: None,
+                goals_before: Some(goals_before),
+                goals_after: Some(goals_after),
+            })
+        }
+    }
+}
+
+/// Handle a `lean_goals_batch` tool call.
+///
+/// Opens each unique file once, then fires concurrent goal queries for all
+/// positions. Returns partial results — individual position failures are
+/// captured in the `error` field rather than failing the whole batch.
+///
+/// `positions` must contain at least one entry; coordinates are 1-indexed.
+pub async fn handle_lean_goals_batch(
+    client: &dyn LspClient,
+    positions: Vec<BatchGoalPosition>,
+) -> Result<BatchGoalResult, LeanToolError> {
+    if positions.is_empty() {
+        return Ok(BatchGoalResult { items: vec![] });
+    }
+
+    // 1. Collect unique file paths and open each once.
+    let unique_files: HashSet<&str> = positions.iter().map(|p| p.file_path.as_str()).collect();
+
+    for file_path in &unique_files {
+        client
+            .open_file(file_path)
+            .await
+            .map_err(|e| LeanToolError::LspError {
+                operation: "open_file".into(),
+                message: e.to_string(),
+            })?;
+    }
+
+    // 2. Pre-fetch file contents for all unique files.
+    let mut file_contents: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    for file_path in &unique_files {
+        let content =
+            client
+                .get_file_content(file_path)
+                .await
+                .map_err(|e| LeanToolError::LspError {
+                    operation: "get_file_content".into(),
+                    message: e.to_string(),
+                })?;
+        file_contents.insert(file_path.to_string(), content);
+    }
+
+    // 3. Fire concurrent goal queries for all positions.
+    let futures: Vec<_> = positions
+        .iter()
+        .map(|pos| {
+            let content = file_contents
+                .get(&pos.file_path)
+                .expect("file content pre-fetched");
+            query_single_goal(client, &pos.file_path, pos.line, pos.column, content)
+        })
+        .collect();
+
+    let results = futures::future::join_all(futures).await;
+
+    // 4. Assemble batch results with partial-failure semantics.
+    let items: Vec<BatchGoalEntry> = positions
+        .into_iter()
+        .zip(results)
+        .map(|(position, result)| match result {
+            Ok(goal_state) => BatchGoalEntry {
+                position,
+                result: Some(goal_state),
+                error: None,
+            },
+            Err(msg) => BatchGoalEntry {
+                position,
+                result: None,
+                error: Some(msg),
+            },
+        })
+        .collect();
+
+    Ok(BatchGoalResult { items })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use serde_json::{json, Value};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A mock LSP client for batch goal tests.
+    struct MockBatchClient {
+        project: PathBuf,
+        /// Map of file path -> content.
+        files: std::collections::HashMap<String, String>,
+        /// Canned goal responses keyed by (file, 0-indexed line, 0-indexed col).
+        goal_responses: Vec<(String, u32, u32, Option<Value>)>,
+        /// Counter for open_file calls (to verify dedup).
+        open_count: AtomicU32,
+    }
+
+    impl MockBatchClient {
+        fn new() -> Self {
+            Self {
+                project: PathBuf::from("/test/project"),
+                files: std::collections::HashMap::new(),
+                goal_responses: Vec::new(),
+                open_count: AtomicU32::new(0),
+            }
+        }
+
+        fn with_file(mut self, path: &str, content: &str) -> Self {
+            self.files.insert(path.to_string(), content.to_string());
+            self
+        }
+
+        fn with_goal(mut self, file: &str, line: u32, col: u32, response: Option<Value>) -> Self {
+            self.goal_responses
+                .push((file.to_string(), line, col, response));
+            self
+        }
+    }
+
+    #[async_trait]
+    impl LspClient for MockBatchClient {
+        fn project_path(&self) -> &Path {
+            &self.project
+        }
+
+        async fn open_file(
+            &self,
+            _relative_path: &str,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            self.open_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn open_file_force(
+            &self,
+            _relative_path: &str,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn get_file_content(
+            &self,
+            relative_path: &str,
+        ) -> Result<String, lean_lsp_client::client::LspClientError> {
+            self.files.get(relative_path).cloned().ok_or(
+                lean_lsp_client::client::LspClientError::FileNotOpen(relative_path.to_string()),
+            )
+        }
+
+        async fn update_file(
+            &self,
+            _relative_path: &str,
+            _changes: Vec<Value>,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn update_file_content(
+            &self,
+            _relative_path: &str,
+            _content: &str,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn close_files(
+            &self,
+            _paths: &[String],
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+
+        async fn get_diagnostics(
+            &self,
+            _relative_path: &str,
+            _start_line: Option<u32>,
+            _end_line: Option<u32>,
+            _inactivity_timeout: Option<f64>,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({}))
+        }
+
+        async fn get_interactive_diagnostics(
+            &self,
+            _relative_path: &str,
+            _start_line: Option<u32>,
+            _end_line: Option<u32>,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_goal(
+            &self,
+            relative_path: &str,
+            line: u32,
+            column: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            for (f, l, c, resp) in &self.goal_responses {
+                if f == relative_path && *l == line && *c == column {
+                    return Ok(resp.clone());
+                }
+            }
+            Ok(None)
+        }
+
+        async fn get_term_goal(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(None)
+        }
+
+        async fn get_hover(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(None)
+        }
+
+        async fn get_completions(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_declarations(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_references(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+            _include_declaration: bool,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_document_symbols(
+            &self,
+            _relative_path: &str,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_code_actions(
+            &self,
+            _relative_path: &str,
+            _start_line: u32,
+            _start_col: u32,
+            _end_line: u32,
+            _end_col: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_code_action_resolve(
+            &self,
+            _action: Value,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({}))
+        }
+
+        async fn get_widgets(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+
+        async fn get_widget_source(
+            &self,
+            _relative_path: &str,
+            _line: u32,
+            _column: u32,
+            _javascript_hash: &str,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({}))
+        }
+
+        async fn shutdown(&self) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+    }
+
+    // ---- Basic batch with multiple positions in one file ----
+
+    #[tokio::test]
+    async fn batch_single_file_multiple_positions() {
+        let client = MockBatchClient::new()
+            .with_file(
+                "Main.lean",
+                "import Mathlib\ntheorem foo : True := by\n  trivial",
+            )
+            .with_goal("Main.lean", 1, 0, Some(json!({"goals": ["⊢ True"]})))
+            .with_goal("Main.lean", 2, 2, Some(json!({"goals": []})));
+
+        let positions = vec![
+            BatchGoalPosition {
+                file_path: "Main.lean".into(),
+                line: 2,
+                column: Some(1),
+            },
+            BatchGoalPosition {
+                file_path: "Main.lean".into(),
+                line: 3,
+                column: Some(3),
+            },
+        ];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        // Both should succeed (possibly with empty goals).
+        assert!(result.items[0].result.is_some());
+        assert!(result.items[0].error.is_none());
+        assert!(result.items[1].result.is_some());
+        assert!(result.items[1].error.is_none());
+    }
+
+    // ---- Opens each unique file only once ----
+
+    #[tokio::test]
+    async fn batch_deduplicates_file_opens() {
+        let client = MockBatchClient::new()
+            .with_file("A.lean", "theorem a : True := by trivial")
+            .with_file("B.lean", "theorem b : True := by trivial");
+
+        let positions = vec![
+            BatchGoalPosition {
+                file_path: "A.lean".into(),
+                line: 1,
+                column: Some(1),
+            },
+            BatchGoalPosition {
+                file_path: "A.lean".into(),
+                line: 1,
+                column: Some(5),
+            },
+            BatchGoalPosition {
+                file_path: "B.lean".into(),
+                line: 1,
+                column: Some(1),
+            },
+        ];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items.len(), 3);
+        // Should open only 2 unique files (A.lean and B.lean).
+        assert_eq!(client.open_count.load(Ordering::SeqCst), 2);
+    }
+
+    // ---- Partial failure: bad position doesn't fail the batch ----
+
+    #[tokio::test]
+    async fn batch_partial_failure_on_bad_line() {
+        let client = MockBatchClient::new()
+            .with_file("Main.lean", "line one\nline two")
+            .with_goal("Main.lean", 0, 0, Some(json!({"goals": ["⊢ True"]})));
+
+        let positions = vec![
+            BatchGoalPosition {
+                file_path: "Main.lean".into(),
+                line: 1,
+                column: Some(1),
+            },
+            BatchGoalPosition {
+                file_path: "Main.lean".into(),
+                line: 99,
+                column: Some(1),
+            },
+        ];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        // First should succeed.
+        assert!(result.items[0].result.is_some());
+        assert!(result.items[0].error.is_none());
+        // Second should fail with line out of range.
+        assert!(result.items[1].result.is_none());
+        assert!(result.items[1].error.is_some());
+        assert!(result.items[1]
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("out of range"));
+    }
+
+    // ---- Partial failure: bad column ----
+
+    #[tokio::test]
+    async fn batch_partial_failure_on_bad_column() {
+        let client = MockBatchClient::new().with_file("Main.lean", "short");
+
+        let positions = vec![BatchGoalPosition {
+            file_path: "Main.lean".into(),
+            line: 1,
+            column: Some(100),
+        }];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items.len(), 1);
+        assert!(result.items[0].result.is_none());
+        assert!(result.items[0]
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("Column 100 out of range"));
+    }
+
+    // ---- Empty positions returns empty result ----
+
+    #[tokio::test]
+    async fn batch_empty_positions() {
+        let client = MockBatchClient::new();
+
+        let result = handle_lean_goals_batch(&client, vec![]).await.unwrap();
+
+        assert!(result.items.is_empty());
+    }
+
+    // ---- Without column returns before/after goals ----
+
+    #[tokio::test]
+    async fn batch_without_column_returns_before_after() {
+        // "  simp" has first non-ws at col 2 (0-indexed), trimmed end at col 6.
+        let client = MockBatchClient::new()
+            .with_file("Main.lean", "theorem foo := by\n  simp\n  done")
+            .with_goal("Main.lean", 1, 2, Some(json!({"goals": ["⊢ 0 = 0"]})))
+            .with_goal("Main.lean", 1, 6, Some(json!({"goals": []})));
+
+        let positions = vec![BatchGoalPosition {
+            file_path: "Main.lean".into(),
+            line: 2,
+            column: None,
+        }];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items.len(), 1);
+        let entry = &result.items[0];
+        assert!(entry.error.is_none());
+        let gs = entry.result.as_ref().unwrap();
+        assert_eq!(gs.line_context, "  simp");
+        assert!(gs.goals.is_none());
+        assert_eq!(gs.goals_before, Some(vec!["⊢ 0 = 0".to_string()]));
+        assert_eq!(gs.goals_after, Some(vec![]));
+    }
+
+    // ---- With column returns exact goals ----
+
+    #[tokio::test]
+    async fn batch_with_column_returns_exact_goals() {
+        let client = MockBatchClient::new()
+            .with_file("Main.lean", "import Mathlib\n  exact h")
+            .with_goal(
+                "Main.lean",
+                1,
+                2,
+                Some(json!({"goals": ["a : Nat\n⊢ a = a"]})),
+            );
+
+        let positions = vec![BatchGoalPosition {
+            file_path: "Main.lean".into(),
+            line: 2,
+            column: Some(3),
+        }];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items.len(), 1);
+        let gs = result.items[0].result.as_ref().unwrap();
+        assert_eq!(gs.goals, Some(vec!["a : Nat\n⊢ a = a".to_string()]));
+        assert!(gs.goals_before.is_none());
+    }
+
+    // ---- Multiple files in one batch ----
+
+    #[tokio::test]
+    async fn batch_multiple_files() {
+        let client = MockBatchClient::new()
+            .with_file("A.lean", "theorem a := by trivial")
+            .with_file("B.lean", "theorem b := by trivial")
+            .with_goal("A.lean", 0, 0, Some(json!({"goals": ["⊢ True"]})))
+            .with_goal("B.lean", 0, 0, Some(json!({"goals": ["⊢ False"]})));
+
+        let positions = vec![
+            BatchGoalPosition {
+                file_path: "A.lean".into(),
+                line: 1,
+                column: Some(1),
+            },
+            BatchGoalPosition {
+                file_path: "B.lean".into(),
+                line: 1,
+                column: Some(1),
+            },
+        ];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert!(result.items[0].result.is_some());
+        assert!(result.items[1].result.is_some());
+        assert_eq!(result.items[0].position.file_path, "A.lean");
+        assert_eq!(result.items[1].position.file_path, "B.lean");
+    }
+
+    // ---- Preserves input order ----
+
+    #[tokio::test]
+    async fn batch_preserves_order() {
+        let client = MockBatchClient::new().with_file("Main.lean", "line1\nline2\nline3");
+
+        let positions = vec![
+            BatchGoalPosition {
+                file_path: "Main.lean".into(),
+                line: 3,
+                column: Some(1),
+            },
+            BatchGoalPosition {
+                file_path: "Main.lean".into(),
+                line: 1,
+                column: Some(1),
+            },
+            BatchGoalPosition {
+                file_path: "Main.lean".into(),
+                line: 2,
+                column: Some(1),
+            },
+        ];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items[0].position.line, 3);
+        assert_eq!(result.items[1].position.line, 1);
+        assert_eq!(result.items[2].position.line, 2);
+    }
+
+    // ---- Line zero returns error ----
+
+    #[tokio::test]
+    async fn batch_line_zero_returns_error() {
+        let client = MockBatchClient::new().with_file("Main.lean", "line one");
+
+        let positions = vec![BatchGoalPosition {
+            file_path: "Main.lean".into(),
+            line: 0,
+            column: Some(1),
+        }];
+
+        let result = handle_lean_goals_batch(&client, positions).await.unwrap();
+
+        assert_eq!(result.items.len(), 1);
+        assert!(result.items[0].error.is_some());
+        assert!(result.items[0]
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("Line 0 out of range"));
+    }
+
+    // ---- Model types are Send + Sync ----
+
+    #[test]
+    fn batch_types_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<BatchGoalPosition>();
+        assert_send_sync::<BatchGoalEntry>();
+        assert_send_sync::<BatchGoalResult>();
+    }
+}

--- a/crates/lean-mcp-server/src/tools/mod.rs
+++ b/crates/lean-mcp-server/src/tools/mod.rs
@@ -1,6 +1,8 @@
 // Tool handlers are wired into MCP routing in a follow-up issue.
 // Suppress dead-code warnings until then.
 #[allow(dead_code)]
+pub mod batch_goals;
+#[allow(dead_code)]
 pub mod build;
 #[allow(dead_code)]
 pub mod code_actions;


### PR DESCRIPTION
## Summary
- Add `lean_goals_batch` beyond-parity feature: query goal states at multiple positions concurrently
- Opens each unique file once, then fires concurrent `get_goal` calls via `futures::future::join_all`
- Partial-result semantics: individual position failures are captured in the `error` field without failing the whole batch
- Preserves input order in results
- Supports both column-specified (exact goals) and column-omitted (before/after goals) modes
- New models in lean-mcp-core: `BatchGoalPosition`, `BatchGoalEntry`, `BatchGoalResult`

## Test plan
- [x] `cargo test --all` — 588 tests pass (11 new handler tests + 6 new model tests)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] CI passes

Closes #52