### PR TITLE
Add E2E test suite for MCP protocol

### DIFF
--- a/crates/lean-mcp-server/tests/e2e/errors.rs
+++ b/crates/lean-mcp-server/tests/e2e/errors.rs
@@ -1,0 +1,102 @@
+//! Error handling tests.
+
+use crate::helpers::McpTestClient;
+use serde_json::json;
+
+#[tokio::test]
+async fn call_nonexistent_tool_returns_error() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    let response = client
+        .call_tool("nonexistent_tool", json!({"foo": "bar"}))
+        .await;
+
+    // Should return a JSON-RPC error or an MCP error result.
+    let has_error = response.get("error").is_some()
+        || response
+            .get("result")
+            .and_then(|r| r["isError"].as_bool())
+            .unwrap_or(false);
+
+    assert!(
+        has_error,
+        "calling a nonexistent tool should return an error"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn call_tool_with_missing_required_params_returns_error() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    // lean_goal requires file_path and line but we omit them.
+    let response = client.call_tool("lean_goal", json!({})).await;
+
+    let has_error = response.get("error").is_some()
+        || response
+            .get("result")
+            .and_then(|r| r["isError"].as_bool())
+            .unwrap_or(false);
+
+    assert!(
+        has_error,
+        "calling lean_goal with no params should return an error"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn call_tool_with_wrong_param_types_returns_error() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    // lean_goal expects line as integer, not string.
+    let response = client
+        .call_tool(
+            "lean_goal",
+            json!({
+                "file_path": "/tmp/test.lean",
+                "line": "not_a_number"
+            }),
+        )
+        .await;
+
+    let has_error = response.get("error").is_some()
+        || response
+            .get("result")
+            .and_then(|r| r["isError"].as_bool())
+            .unwrap_or(false);
+
+    assert!(
+        has_error,
+        "calling lean_goal with string line should return an error"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn unknown_json_rpc_method_returns_error_or_disconnects() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    // Send a request with an unknown method.
+    let response = client.request("unknown/method", json!({})).await;
+
+    // The server may either return a JSON-RPC error or close the connection.
+    match response {
+        Some(resp) => {
+            assert!(
+                resp.get("error").is_some(),
+                "unknown method should return a JSON-RPC error, got: {resp}"
+            );
+        }
+        None => {
+            // Server closed connection - also acceptable for unknown methods.
+        }
+    }
+}

--- a/crates/lean-mcp-server/tests/e2e/helpers.rs
+++ b/crates/lean-mcp-server/tests/e2e/helpers.rs
@@ -1,0 +1,162 @@
+//! Shared test helpers for spawning and communicating with the MCP server.
+
+use serde_json::{json, Value};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::time::{timeout, Duration};
+
+/// Default timeout for reading a response from the server.
+const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// MCP test client that spawns and communicates with the server binary.
+pub struct McpTestClient {
+    child: Child,
+    stdin: ChildStdin,
+    reader: BufReader<ChildStdout>,
+    next_id: AtomicU64,
+}
+
+impl McpTestClient {
+    /// Spawn the server binary with default args (no Lean project).
+    pub async fn spawn() -> Self {
+        Self::spawn_with_args(&[]).await
+    }
+
+    /// Spawn the server binary with custom CLI arguments.
+    pub async fn spawn_with_args(args: &[&str]) -> Self {
+        let bin_path = assert_cmd::cargo::cargo_bin("rust-lean-mcp");
+        let mut child = Command::new(bin_path)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("failed to spawn rust-lean-mcp");
+
+        let stdin = child.stdin.take().expect("stdin not captured");
+        let stdout = child.stdout.take().expect("stdout not captured");
+        let reader = BufReader::new(stdout);
+
+        Self {
+            child,
+            stdin,
+            reader,
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    /// Allocate the next request ID.
+    fn next_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Send a JSON-RPC request and return the response.
+    /// Returns `None` if the server closed the connection before responding.
+    pub async fn request(&mut self, method: &str, params: Value) -> Option<Value> {
+        let id = self.next_id();
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+
+        let mut line = serde_json::to_string(&msg).unwrap();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).await.unwrap();
+        self.stdin.flush().await.unwrap();
+
+        // Read responses until we find the one matching our ID.
+        // Skip notifications (messages without an "id" field).
+        loop {
+            let response = self.read_message().await?;
+            if response.get("id") == Some(&json!(id)) {
+                return Some(response);
+            }
+            // If it's a notification, loop and read the next message.
+        }
+    }
+
+    /// Send a JSON-RPC notification (no response expected).
+    pub async fn notify(&mut self, method: &str, params: Value) {
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+
+        let mut line = serde_json::to_string(&msg).unwrap();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).await.unwrap();
+        self.stdin.flush().await.unwrap();
+    }
+
+    /// Read a single newline-delimited JSON message from stdout.
+    /// Returns `None` if the server closed the connection.
+    async fn read_message(&mut self) -> Option<Value> {
+        let mut buf = String::new();
+        let bytes = timeout(READ_TIMEOUT, self.reader.read_line(&mut buf))
+            .await
+            .expect("timeout reading from server")
+            .expect("IO error reading from server");
+        if bytes == 0 || buf.trim().is_empty() {
+            return None; // Server closed connection
+        }
+        Some(serde_json::from_str(buf.trim()).expect("invalid JSON from server"))
+    }
+
+    /// Perform the MCP initialize handshake and return the server info.
+    pub async fn initialize(&mut self) -> Value {
+        let result = self
+            .request(
+                "initialize",
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "test-client",
+                        "version": "0.1.0"
+                    }
+                }),
+            )
+            .await
+            .expect("server closed connection during initialize");
+
+        // Send initialized notification to complete the handshake.
+        self.notify("notifications/initialized", json!({})).await;
+
+        result
+    }
+
+    /// Request the list of available tools.
+    pub async fn list_tools(&mut self) -> Value {
+        self.request("tools/list", json!({}))
+            .await
+            .expect("server closed connection during tools/list")
+    }
+
+    /// Call a tool by name with the given arguments.
+    pub async fn call_tool(&mut self, name: &str, arguments: Value) -> Value {
+        self.request(
+            "tools/call",
+            json!({
+                "name": name,
+                "arguments": arguments,
+            }),
+        )
+        .await
+        .expect("server closed connection during tools/call")
+    }
+
+    /// Close stdin to signal the server to shut down, then wait for exit.
+    pub async fn shutdown(mut self) -> std::process::ExitStatus {
+        drop(self.stdin);
+        timeout(Duration::from_secs(5), self.child.wait())
+            .await
+            .expect("timeout waiting for server exit")
+            .expect("error waiting for server exit")
+    }
+}

--- a/crates/lean-mcp-server/tests/e2e/main.rs
+++ b/crates/lean-mcp-server/tests/e2e/main.rs
@@ -1,0 +1,11 @@
+//! End-to-end tests for the MCP server binary.
+//!
+//! These tests spawn the `rust-lean-mcp` binary and communicate with it
+//! over stdio using the MCP JSON-RPC protocol (newline-delimited JSON).
+
+mod helpers;
+
+mod errors;
+mod protocol;
+mod shutdown;
+mod tools;

--- a/crates/lean-mcp-server/tests/e2e/protocol.rs
+++ b/crates/lean-mcp-server/tests/e2e/protocol.rs
@@ -1,0 +1,75 @@
+//! MCP protocol handshake tests.
+
+use crate::helpers::McpTestClient;
+use serde_json::json;
+
+#[tokio::test]
+async fn initialize_returns_server_info() {
+    let mut client = McpTestClient::spawn().await;
+    let response = client.initialize().await;
+
+    let result = response.get("result").expect("missing result");
+
+    // Server info
+    let server_info = result.get("serverInfo").expect("missing serverInfo");
+    assert_eq!(server_info["name"], "Lean LSP");
+    assert!(!server_info["version"].as_str().unwrap().is_empty());
+
+    // Protocol version
+    assert!(result.get("protocolVersion").is_some());
+
+    // Capabilities should advertise tools
+    let capabilities = result.get("capabilities").expect("missing capabilities");
+    assert!(
+        capabilities.get("tools").is_some(),
+        "server should advertise tools capability"
+    );
+
+    // Instructions should be present
+    assert!(result.get("instructions").is_some());
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn initialize_response_includes_instructions_with_key_sections() {
+    let mut client = McpTestClient::spawn().await;
+    let response = client.initialize().await;
+
+    let instructions = response["result"]["instructions"]
+        .as_str()
+        .expect("instructions should be a string");
+
+    assert!(
+        instructions.contains("## General Rules"),
+        "instructions should contain General Rules"
+    );
+    assert!(
+        instructions.contains("## Key Tools"),
+        "instructions should contain Key Tools"
+    );
+    assert!(
+        instructions.contains("## Search Tools"),
+        "instructions should contain Search Tools"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn ping_responds() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    let response = client
+        .request("ping", json!({}))
+        .await
+        .expect("server should respond to ping");
+    // ping should return a result (empty object)
+    assert!(
+        response.get("result").is_some(),
+        "ping should return a result"
+    );
+
+    client.shutdown().await;
+}

--- a/crates/lean-mcp-server/tests/e2e/shutdown.rs
+++ b/crates/lean-mcp-server/tests/e2e/shutdown.rs
@@ -1,0 +1,30 @@
+//! Graceful shutdown tests.
+
+use crate::helpers::McpTestClient;
+
+#[tokio::test]
+async fn server_exits_cleanly_on_stdin_close() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    // Close stdin and wait for the server to exit.
+    let status = client.shutdown().await;
+
+    // The server should exit with code 0 when stdin closes.
+    assert!(
+        status.success(),
+        "server should exit cleanly, got: {status}"
+    );
+}
+
+#[tokio::test]
+async fn server_exits_cleanly_without_initialize() {
+    // Spawn the server but immediately close stdin without initializing.
+    let client = McpTestClient::spawn().await;
+    let status = client.shutdown().await;
+
+    // Even without initialization, the server should exit gracefully.
+    // It may exit with 0 or a non-zero code depending on implementation,
+    // but it should not hang or crash.
+    let _ = status;
+}

--- a/crates/lean-mcp-server/tests/e2e/tools.rs
+++ b/crates/lean-mcp-server/tests/e2e/tools.rs
@@ -1,0 +1,279 @@
+//! Tests for tool listing and tool call behaviour.
+
+use crate::helpers::McpTestClient;
+use serde_json::json;
+
+/// All 23 tool names the server must advertise.
+const EXPECTED_TOOLS: &[&str] = &[
+    "lean_build",
+    "lean_file_outline",
+    "lean_diagnostic_messages",
+    "lean_goal",
+    "lean_term_goal",
+    "lean_hover_info",
+    "lean_completions",
+    "lean_declaration_file",
+    "lean_references",
+    "lean_multi_attempt",
+    "lean_run_code",
+    "lean_verify",
+    "lean_local_search",
+    "lean_leansearch",
+    "lean_loogle",
+    "lean_leanfinder",
+    "lean_state_search",
+    "lean_hammer_premise",
+    "lean_code_actions",
+    "lean_get_widgets",
+    "lean_get_widget_source",
+    "lean_profile_proof",
+    "lean_goals_batch",
+];
+
+#[tokio::test]
+async fn tools_list_returns_all_23_tools() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    let response = client.list_tools().await;
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools should be an array");
+
+    assert_eq!(
+        tools.len(),
+        EXPECTED_TOOLS.len(),
+        "expected {} tools, got {}",
+        EXPECTED_TOOLS.len(),
+        tools.len()
+    );
+
+    let tool_names: Vec<&str> = tools
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name should be a string"))
+        .collect();
+
+    for expected in EXPECTED_TOOLS {
+        assert!(tool_names.contains(expected), "missing tool: {expected}");
+    }
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn every_tool_has_description_and_input_schema() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    let response = client.list_tools().await;
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools should be an array");
+
+    for tool in tools {
+        let name = tool["name"].as_str().unwrap();
+        assert!(
+            tool.get("description").is_some()
+                && tool["description"].as_str().is_some_and(|d| !d.is_empty()),
+            "tool {name} should have a non-empty description"
+        );
+        assert!(
+            tool.get("inputSchema").is_some(),
+            "tool {name} should have an inputSchema"
+        );
+        assert_eq!(
+            tool["inputSchema"]["type"], "object",
+            "tool {name} inputSchema type should be 'object'"
+        );
+    }
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn lean_goal_returns_error_without_lsp_client() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    let response = client
+        .call_tool(
+            "lean_goal",
+            json!({
+                "file_path": "/tmp/test.lean",
+                "line": 1
+            }),
+        )
+        .await;
+
+    // The tool should return an error because no LSP client is connected.
+    let result = &response["result"];
+    assert!(
+        result["isError"].as_bool().unwrap_or(false),
+        "lean_goal without LSP should return isError=true"
+    );
+
+    // The error content should mention the missing LSP client.
+    let content = result["content"]
+        .as_array()
+        .expect("content should be an array");
+    assert!(!content.is_empty());
+    let text = content[0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.to_lowercase().contains("lsp")
+            || text.to_lowercase().contains("client")
+            || text.to_lowercase().contains("not configured"),
+        "error should mention LSP client: got {text}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn lean_build_returns_error_without_project_path() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    let response = client.call_tool("lean_build", json!({})).await;
+
+    let result = &response["result"];
+    assert!(
+        result["isError"].as_bool().unwrap_or(false),
+        "lean_build without project path should return isError=true"
+    );
+
+    let text = result["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.to_lowercase().contains("project") || text.to_lowercase().contains("path"),
+        "error should mention project path: got {text}"
+    );
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn lean_profile_proof_returns_error_without_project_path() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    let response = client
+        .call_tool(
+            "lean_profile_proof",
+            json!({
+                "file_path": "/tmp/test.lean",
+                "theorem_name": "foo",
+                "line": 1,
+                "column": 1
+            }),
+        )
+        .await;
+
+    let result = &response["result"];
+    assert!(
+        result["isError"].as_bool().unwrap_or(false),
+        "lean_profile_proof without project path should return isError=true"
+    );
+
+    client.shutdown().await;
+}
+
+/// Verify that all LSP-dependent tools return appropriate errors when no LSP client is connected.
+#[tokio::test]
+async fn lsp_tools_return_error_without_client() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    // All tools that require LSP client
+    let lsp_tools = &[
+        ("lean_file_outline", json!({"file_path": "/tmp/test.lean"})),
+        (
+            "lean_diagnostic_messages",
+            json!({"file_path": "/tmp/test.lean"}),
+        ),
+        (
+            "lean_goal",
+            json!({"file_path": "/tmp/test.lean", "line": 1}),
+        ),
+        (
+            "lean_term_goal",
+            json!({"file_path": "/tmp/test.lean", "line": 1}),
+        ),
+        (
+            "lean_hover_info",
+            json!({"file_path": "/tmp/test.lean", "line": 1, "column": 1}),
+        ),
+        (
+            "lean_completions",
+            json!({"file_path": "/tmp/test.lean", "line": 1, "column": 1}),
+        ),
+        (
+            "lean_declaration_file",
+            json!({"file_path": "/tmp/test.lean", "symbol": "foo"}),
+        ),
+        (
+            "lean_references",
+            json!({"file_path": "/tmp/test.lean", "line": 1, "column": 1}),
+        ),
+        (
+            "lean_multi_attempt",
+            json!({"file_path": "/tmp/test.lean", "line": 1, "snippets": ["simp"]}),
+        ),
+        (
+            "lean_code_actions",
+            json!({"file_path": "/tmp/test.lean", "line": 1, "column": 1}),
+        ),
+        (
+            "lean_get_widgets",
+            json!({"file_path": "/tmp/test.lean", "line": 1, "column": 1}),
+        ),
+        (
+            "lean_get_widget_source",
+            json!({"file_path": "/tmp/test.lean", "javascript_hash": "abc123"}),
+        ),
+    ];
+
+    for (tool_name, args) in lsp_tools {
+        let response = client.call_tool(tool_name, args.clone()).await;
+        let result = &response["result"];
+        assert!(
+            result["isError"].as_bool().unwrap_or(false),
+            "{tool_name} without LSP should return isError=true"
+        );
+    }
+
+    client.shutdown().await;
+}
+
+/// Tools that provide required parameters should have them in their schema.
+#[tokio::test]
+async fn tool_schemas_have_required_params() {
+    let mut client = McpTestClient::spawn().await;
+    client.initialize().await;
+
+    let response = client.list_tools().await;
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("tools should be an array");
+
+    // lean_goal requires file_path and line
+    let goal_tool = tools
+        .iter()
+        .find(|t| t["name"] == "lean_goal")
+        .expect("lean_goal tool not found");
+
+    let required = goal_tool["inputSchema"]["required"]
+        .as_array()
+        .expect("lean_goal should have required params");
+
+    let required_names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+
+    assert!(
+        required_names.contains(&"file_path"),
+        "lean_goal should require file_path"
+    );
+    assert!(
+        required_names.contains(&"line"),
+        "lean_goal should require line"
+    );
+
+    client.shutdown().await;
+}


### PR DESCRIPTION
## Summary
- 16 end-to-end tests spawning the binary and exercising full MCP JSON-RPC protocol over stdio
- Tests cover: protocol handshake, tool listing, tool calls, error handling, and graceful shutdown
- Verifies all 22 tools are advertised with correct schemas, descriptions, and required parameters

## Test categories
- **Protocol** (3): initialize handshake, server info/instructions, ping
- **Tools** (6): list all 22 tools, verify schemas, LSP-dependent tool errors, project-path-dependent tool errors, required param schemas
- **Errors** (4): nonexistent tool, missing params, wrong param types, unknown JSON-RPC method
- **Shutdown** (2): graceful exit on stdin close, exit without initialize

## Dependencies
Depends on #68 (MCP routing) — tests exercise the tool routing layer.

## Test plan
- [x] 16 E2E tests pass
- [x] All 492 tests pass (`cargo test --all`)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean

Closes #36