### PR TITLE
fix: handle string-typed JSON-RPC IDs in multiplexer

### DIFF
--- a/crates/lean-lsp-client/benches/transport_bench.rs
+++ b/crates/lean-lsp-client/benches/transport_bench.rs
@@ -1,5 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use lean_lsp_client::jsonrpc::{Message, Notification, Request, Response, ResponseError};
+use lean_lsp_client::jsonrpc::{
+    Message, Notification, Request, RequestId, Response, ResponseError,
+};
 use lean_lsp_client::transport::{read_message, write_message};
 use serde_json::json;
 
@@ -31,7 +33,7 @@ fn bench_request_deserialize(c: &mut Criterion) {
 fn bench_response_serialize(c: &mut Criterion) {
     let resp = Response {
         jsonrpc: "2.0".to_string(),
-        id: Some(1),
+        id: Some(RequestId::Number(1)),
         result: Some(json!({
             "contents": {"kind": "markdown", "value": "```lean\nNat.add : Nat → Nat → Nat\n```"}
         })),
@@ -52,7 +54,7 @@ fn bench_response_deserialize(c: &mut Criterion) {
 fn bench_response_error_serialize(c: &mut Criterion) {
     let resp = Response {
         jsonrpc: "2.0".to_string(),
-        id: Some(1),
+        id: Some(RequestId::Number(1)),
         result: None,
         error: Some(ResponseError {
             code: -32601,

--- a/crates/lean-lsp-client/src/jsonrpc.rs
+++ b/crates/lean-lsp-client/src/jsonrpc.rs
@@ -2,6 +2,26 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt;
+
+/// A JSON-RPC 2.0 request ID, which can be a number or a string per the spec.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RequestId {
+    /// Numeric request ID.
+    Number(i64),
+    /// String request ID (e.g., Lean's `register_lean_watcher`).
+    String(String),
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RequestId::Number(n) => write!(f, "{n}"),
+            RequestId::String(s) => write!(f, "\"{s}\""),
+        }
+    }
+}
 
 /// A JSON-RPC 2.0 request message.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -9,7 +29,7 @@ pub struct Request {
     /// Protocol version, always "2.0".
     pub jsonrpc: String,
     /// Unique identifier for the request.
-    pub id: i64,
+    pub id: RequestId,
     /// The method to invoke.
     pub method: String,
     /// Optional parameters for the method.
@@ -23,7 +43,7 @@ pub struct Response {
     /// Protocol version, always "2.0".
     pub jsonrpc: String,
     /// The id of the request this response corresponds to.
-    pub id: Option<i64>,
+    pub id: Option<RequestId>,
     /// The result of a successful request.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<Value>,
@@ -57,11 +77,11 @@ pub struct Notification {
 }
 
 impl Request {
-    /// Create a new JSON-RPC request.
+    /// Create a new JSON-RPC request with a numeric ID.
     pub fn new(id: i64, method: &str, params: Option<Value>) -> Self {
         Self {
             jsonrpc: "2.0".to_string(),
-            id,
+            id: RequestId::Number(id),
             method: method.to_string(),
             params,
         }
@@ -124,7 +144,7 @@ mod tests {
     fn test_request_new() {
         let req = Request::new(1, "initialize", Some(json!({"rootUri": "file:///tmp"})));
         assert_eq!(req.jsonrpc, "2.0");
-        assert_eq!(req.id, 1);
+        assert_eq!(req.id, RequestId::Number(1));
         assert_eq!(req.method, "initialize");
         assert_eq!(req.params, Some(json!({"rootUri": "file:///tmp"})));
     }
@@ -133,7 +153,7 @@ mod tests {
     fn test_request_new_without_params() {
         let req = Request::new(42, "shutdown", None);
         assert_eq!(req.jsonrpc, "2.0");
-        assert_eq!(req.id, 42);
+        assert_eq!(req.id, RequestId::Number(42));
         assert_eq!(req.method, "shutdown");
         assert_eq!(req.params, None);
     }
@@ -164,9 +184,17 @@ mod tests {
         let json_str =
             r#"{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"rootUri":"file:///tmp"}}"#;
         let req: Request = serde_json::from_str(json_str).unwrap();
-        assert_eq!(req.id, 3);
+        assert_eq!(req.id, RequestId::Number(3));
         assert_eq!(req.method, "initialize");
         assert_eq!(req.params, Some(json!({"rootUri": "file:///tmp"})));
+    }
+
+    #[test]
+    fn test_request_with_string_id_deserialization() {
+        let json_str = r#"{"jsonrpc":"2.0","id":"register-1","method":"client/registerCapability","params":{}}"#;
+        let req: Request = serde_json::from_str(json_str).unwrap();
+        assert_eq!(req.id, RequestId::String("register-1".to_string()));
+        assert_eq!(req.method, "client/registerCapability");
     }
 
     #[test]
@@ -181,7 +209,7 @@ mod tests {
     fn test_response_with_result() {
         let resp = Response {
             jsonrpc: "2.0".to_string(),
-            id: Some(1),
+            id: Some(RequestId::Number(1)),
             result: Some(json!({"capabilities": {}})),
             error: None,
         };
@@ -195,7 +223,7 @@ mod tests {
     fn test_response_with_error() {
         let resp = Response {
             jsonrpc: "2.0".to_string(),
-            id: Some(1),
+            id: Some(RequestId::Number(1)),
             result: None,
             error: Some(ResponseError {
                 code: -32601,
@@ -225,9 +253,16 @@ mod tests {
         let json_str =
             r#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"hoverProvider":true}}}"#;
         let resp: Response = serde_json::from_str(json_str).unwrap();
-        assert_eq!(resp.id, Some(1));
+        assert_eq!(resp.id, Some(RequestId::Number(1)));
         assert!(resp.result.is_some());
         assert!(resp.error.is_none());
+    }
+
+    #[test]
+    fn test_response_with_string_id_deserialization() {
+        let json_str = r#"{"jsonrpc":"2.0","id":"abc-123","result":null}"#;
+        let resp: Response = serde_json::from_str(json_str).unwrap();
+        assert_eq!(resp.id, Some(RequestId::String("abc-123".to_string())));
     }
 
     #[test]
@@ -262,8 +297,19 @@ mod tests {
         let msg = Message::from_value(value).unwrap();
         assert!(matches!(msg, Message::Request(_)));
         if let Message::Request(req) = msg {
-            assert_eq!(req.id, 1);
+            assert_eq!(req.id, RequestId::Number(1));
             assert_eq!(req.method, "initialize");
+        }
+    }
+
+    #[test]
+    fn test_message_from_value_request_with_string_id() {
+        let value = json!({"jsonrpc":"2.0","id":"lean-watcher-1","method":"client/registerCapability","params":{}});
+        let msg = Message::from_value(value).unwrap();
+        assert!(matches!(msg, Message::Request(_)));
+        if let Message::Request(req) = msg {
+            assert_eq!(req.id, RequestId::String("lean-watcher-1".to_string()));
+            assert_eq!(req.method, "client/registerCapability");
         }
     }
 
@@ -273,7 +319,7 @@ mod tests {
         let msg = Message::from_value(value).unwrap();
         assert!(matches!(msg, Message::Response(_)));
         if let Message::Response(resp) = msg {
-            assert_eq!(resp.id, Some(1));
+            assert_eq!(resp.id, Some(RequestId::Number(1)));
         }
     }
 
@@ -295,9 +341,32 @@ mod tests {
         let msg = Message::from_value(value).unwrap();
         assert!(matches!(msg, Message::Response(_)));
         if let Message::Response(resp) = msg {
-            assert_eq!(resp.id, Some(5));
+            assert_eq!(resp.id, Some(RequestId::Number(5)));
             assert!(resp.error.is_some());
             assert_eq!(resp.error.unwrap().code, -32601);
         }
+    }
+
+    #[test]
+    fn test_request_id_display() {
+        assert_eq!(format!("{}", RequestId::Number(42)), "42");
+        assert_eq!(
+            format!("{}", RequestId::String("abc".to_string())),
+            "\"abc\""
+        );
+    }
+
+    #[test]
+    fn test_request_id_hash_equality() {
+        use std::collections::HashMap;
+        let mut map = HashMap::new();
+        map.insert(RequestId::Number(1), "numeric");
+        map.insert(RequestId::String("abc".to_string()), "string");
+        assert_eq!(map.get(&RequestId::Number(1)), Some(&"numeric"));
+        assert_eq!(
+            map.get(&RequestId::String("abc".to_string())),
+            Some(&"string")
+        );
+        assert_eq!(map.get(&RequestId::Number(2)), None);
     }
 }

--- a/crates/lean-lsp-client/src/multiplexer.rs
+++ b/crates/lean-lsp-client/src/multiplexer.rs
@@ -14,7 +14,7 @@ use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::{debug, error, warn};
 
 use crate::error::TransportError;
-use crate::jsonrpc::{Message, Notification, Request};
+use crate::jsonrpc::{Message, Notification, Request, RequestId};
 use crate::transport::{read_message, write_message};
 
 /// Default timeout for requests (30 seconds).
@@ -57,7 +57,7 @@ pub struct Multiplexer {
     /// Channel to send outgoing messages to the writer task.
     outgoing_tx: mpsc::Sender<Value>,
     /// Pending requests awaiting responses, keyed by request ID.
-    pending: Arc<Mutex<HashMap<i64, PendingRequest>>>,
+    pending: Arc<Mutex<HashMap<RequestId, PendingRequest>>>,
     /// Next request ID.
     next_id: Arc<Mutex<i64>>,
     /// Notification handler.
@@ -79,7 +79,7 @@ impl Multiplexer {
         R: AsyncBufRead + Unpin + Send + 'static,
         W: AsyncWrite + Unpin + Send + 'static,
     {
-        let pending: Arc<Mutex<HashMap<i64, PendingRequest>>> =
+        let pending: Arc<Mutex<HashMap<RequestId, PendingRequest>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let notification_handler: Arc<Mutex<Option<NotificationHandler>>> =
             Arc::new(Mutex::new(None));
@@ -143,12 +143,13 @@ impl Multiplexer {
         timeout: Duration,
     ) -> Result<Value, MultiplexerError> {
         // 1. Allocate next request ID.
-        let id = {
+        let numeric_id = {
             let mut next = self.next_id.lock().await;
             let id = *next;
             *next += 1;
             id
         };
+        let id = RequestId::Number(numeric_id);
 
         // 2. Create oneshot channel.
         let (tx, rx) = oneshot::channel();
@@ -156,15 +157,15 @@ impl Multiplexer {
         // 3. Register in pending map.
         {
             let mut pending = self.pending.lock().await;
-            pending.insert(id, tx);
+            pending.insert(id.clone(), tx);
         }
 
         // 4. Build and send request via outgoing channel.
-        let request = Request::new(id, method, params);
+        let request = Request::new(numeric_id, method, params);
         let msg_value = serde_json::to_value(&request)
             .map_err(|e| MultiplexerError::Transport(TransportError::Json(e)))?;
 
-        debug!(id, method, "Sending request");
+        debug!(%id, method, "Sending request");
 
         self.outgoing_tx
             .send(msg_value)
@@ -219,7 +220,7 @@ impl Multiplexer {
         {
             let mut pending = self.pending.lock().await;
             for (id, sender) in pending.drain() {
-                debug!(id, "Cancelling pending request due to shutdown");
+                debug!(%id, "Cancelling pending request due to shutdown");
                 // Send a null value to indicate cancellation; the receiver
                 // will see this as a successful receive but with a sentinel.
                 // However, dropping the sender is cleaner since the receiver
@@ -246,7 +247,7 @@ impl Multiplexer {
     /// Background reader loop: reads messages and dispatches them.
     async fn reader_loop<R: AsyncBufRead + Unpin>(
         mut reader: R,
-        pending: Arc<Mutex<HashMap<i64, PendingRequest>>>,
+        pending: Arc<Mutex<HashMap<RequestId, PendingRequest>>>,
         notification_handler: Arc<Mutex<Option<NotificationHandler>>>,
     ) {
         loop {
@@ -279,7 +280,7 @@ impl Multiplexer {
     /// Dispatch a single parsed message to the correct handler.
     async fn dispatch_message(
         value: Value,
-        pending: &Arc<Mutex<HashMap<i64, PendingRequest>>>,
+        pending: &Arc<Mutex<HashMap<RequestId, PendingRequest>>>,
         notification_handler: &Arc<Mutex<Option<NotificationHandler>>>,
     ) {
         match Message::from_value(value.clone()) {
@@ -290,9 +291,9 @@ impl Multiplexer {
                         // Send the full response value so the caller can
                         // inspect result/error.
                         let _ = sender.send(value);
-                        debug!(id, "Dispatched response to pending request");
+                        debug!(%id, "Dispatched response to pending request");
                     } else {
-                        warn!(id, "Received response for unknown request ID");
+                        warn!(%id, "Received response for unknown request ID");
                     }
                 }
             }
@@ -307,7 +308,7 @@ impl Multiplexer {
             Ok(Message::Request(req)) => {
                 // Server-to-client requests (e.g., window/showMessageRequest).
                 // We log but don't handle them for now.
-                debug!(id = req.id, method = %req.method, "Received server request (unhandled)");
+                debug!(id = %req.id, method = %req.method, "Received server request (unhandled)");
             }
             Err(e) => {
                 warn!(?e, "Failed to parse incoming message");
@@ -510,7 +511,7 @@ mod tests {
         let (tx, rx) = oneshot::channel();
         {
             let mut pending = mux.pending.lock().await;
-            pending.insert(999, tx);
+            pending.insert(RequestId::Number(999), tx);
         }
 
         // Shutdown should cancel the pending request by dropping all senders.
@@ -672,7 +673,7 @@ mod tests {
         let (_tx_unused, rx) = {
             let (tx, rx) = oneshot::channel::<Value>();
             let mut pending = mux.pending.lock().await;
-            pending.insert(999, tx);
+            pending.insert(RequestId::Number(999), tx);
             ((), rx)
         };
 
@@ -756,6 +757,76 @@ mod tests {
         assert_eq!(result["result"]["contents"], "Nat");
 
         server.await.unwrap();
+        mux.shutdown().await.unwrap();
+    }
+
+    // ── Test 16: Server request with string ID is handled ─────────
+
+    #[tokio::test]
+    async fn test_server_request_with_string_id_does_not_crash() {
+        let (mut server_writer, client_reader) = make_duplex(4096);
+        let (client_writer, server_reader) = make_duplex(4096);
+
+        let mux = Multiplexer::new(client_reader, client_writer);
+
+        // Server sends a request with a string ID (e.g., Lean's register_lean_watcher).
+        let server = tokio::spawn(async move {
+            let server_req = json!({
+                "jsonrpc": "2.0",
+                "id": "lean-watcher-1",
+                "method": "client/registerCapability",
+                "params": {"registrations": []}
+            });
+            write_message(&mut server_writer, &server_req)
+                .await
+                .unwrap();
+
+            // Then read and respond to a normal client request.
+            let mut reader = BufReader::new(server_reader);
+            let req = read_message(&mut reader).await.unwrap();
+            let id = req["id"].as_i64().unwrap();
+            let resp = json!({"jsonrpc": "2.0", "id": id, "result": "ok"});
+            write_message(&mut server_writer, &resp).await.unwrap();
+        });
+
+        // Give the reader time to process the string-ID request without crashing.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Normal request should still work after receiving a string-ID server request.
+        let result = mux.request("test/method", None).await.unwrap();
+        assert_eq!(result["result"], "ok");
+
+        server.await.unwrap();
+        mux.shutdown().await.unwrap();
+    }
+
+    // ── Test 17: Response with string ID dispatched correctly ─────
+
+    #[tokio::test]
+    async fn test_response_with_string_id_dispatched() {
+        let (mut server_writer, client_reader) = make_duplex(4096);
+        let (client_writer, _server_reader) = make_duplex(4096);
+
+        let mux = Multiplexer::new(client_reader, client_writer);
+
+        // Manually register a pending request with a string ID.
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = mux.pending.lock().await;
+            pending.insert(RequestId::String("custom-id".to_string()), tx);
+        }
+
+        // Server sends a response with that string ID.
+        let resp = json!({"jsonrpc": "2.0", "id": "custom-id", "result": {"data": "found"}});
+        write_message(&mut server_writer, &resp).await.unwrap();
+
+        // The pending request should receive the response.
+        let result = tokio::time::timeout(Duration::from_secs(1), rx)
+            .await
+            .expect("should not timeout")
+            .expect("channel should not be dropped");
+        assert_eq!(result["result"]["data"], "found");
+
         mux.shutdown().await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- Add `RequestId` enum (`Number(i64)` | `String(String)`) with `#[serde(untagged)]` to support both numeric and string JSON-RPC IDs per the spec
- Update multiplexer's pending request map from `HashMap<i64, _>` to `HashMap<RequestId, _>` so string-ID responses are dispatched correctly
- Update tracing macros to use `%id` (Display) instead of bare `id` since `RequestId` is no longer a primitive

Lean's LSP server sends requests with string IDs (e.g., `register_lean_watcher`), which previously caused deserialization failures and lost responses in the multiplexer.

Outgoing requests still use auto-incrementing numeric IDs; incoming responses and server-initiated requests now handle both types.

## Test plan
- [x] New unit tests: string ID deserialization, `Message::from_value` with string ID, `RequestId` Display/Hash
- [x] New multiplexer tests: server request with string ID doesn't crash, response with string ID dispatched correctly
- [x] All 108 lean-lsp-client tests pass
- [x] All 21 E2E tests pass
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p lean-lsp-client --all-targets -- -D warnings` clean
- [x] Updated benchmark file for `RequestId` type change

Closes #15