### PR TITLE
fix: stabilize flaky E2E test

### DIFF
--- a/crates/lean-mcp-server/tests/e2e/helpers.rs
+++ b/crates/lean-mcp-server/tests/e2e/helpers.rs
@@ -8,7 +8,7 @@ use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::time::{timeout, Duration};
 
 /// Default timeout for reading a response from the server.
-const READ_TIMEOUT: Duration = Duration::from_secs(10);
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// MCP test client that spawns and communicates with the server binary.
 pub struct McpTestClient {

--- a/crates/lean-mcp-server/tests/e2e/integration.rs
+++ b/crates/lean-mcp-server/tests/e2e/integration.rs
@@ -184,13 +184,11 @@ async fn multiple_tool_calls_dont_crash() {
     client.initialize().await;
 
     // Call several different tools in sequence
+    // Use only tools that don't make external HTTP calls (avoid flaky API timeouts)
     let tools = [
         ("lean_local_search", json!({"query": "test"})),
         ("lean_local_search", json!({"query": "add_comm"})),
-        (
-            "lean_loogle",
-            json!({"query": "Nat -> Nat", "num_results": 3}),
-        ),
+        ("lean_local_search", json!({"query": "theorem"})),
     ];
 
     for (name, args) in &tools {


### PR DESCRIPTION
Removes external HTTP call from sequential tool test. Bumps timeout to 30s.