### PR TITLE
feat: hybrid async multi_attempt defaults to warm LSP over temp files

### DIFF
--- a/crates/lean-mcp-server/src/server.rs
+++ b/crates/lean-mcp-server/src/server.rs
@@ -165,6 +165,10 @@ pub struct MultiAttemptAsyncParams {
     pub column: Option<u32>,
     #[schemars(description = "Max seconds per snippet (returns 'timeout' for slow tactics)")]
     pub timeout_per_snippet: Option<f64>,
+    #[schemars(
+        description = "Use independent temp files per snippet (slow but isolated). Default: false (uses warm LSP)"
+    )]
+    pub isolated: Option<bool>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -865,17 +869,13 @@ impl AppContext {
 
     #[tool(
         name = "lean_multi_attempt_async",
-        description = "Submit background tactic attempts. Returns task_id immediately. Poll with lean_task_result."
+        description = "Submit background tactic attempts. Returns task_id immediately. Poll with lean_task_result. Uses warm LSP by default (fast). Set isolated=true for independent temp files."
     )]
     async fn lean_multi_attempt_async(
         &self,
         Parameters(params): Parameters<MultiAttemptAsyncParams>,
     ) -> Result<String, String> {
-        // column is accepted for API compatibility but unused in the async/parallel path
-        let _ = params.column;
-
         let client = self.client_for_file(&params.file_path).await?;
-        let project_path = client.project_path().to_path_buf();
 
         // Ensure file is open before reading content (#90)
         client
@@ -897,46 +897,96 @@ impl AppContext {
             ));
         }
 
-        let base_code = lines[..params.line as usize - 1].join("\n");
-        let target_line = lines[(params.line - 1) as usize];
-        let indent_len = target_line.find(|c: char| !c.is_whitespace()).unwrap_or(0);
-        let indent = target_line[..indent_len].to_string();
-
         // Create task
         let (task_id, cancel_token) = self.task_manager.create_task(params.snippets.len()).await;
 
-        // Spawn each snippet as an independent background task
+        let isolated = params.isolated.unwrap_or(false);
         let timeout = params.timeout_per_snippet;
-        for (i, snippet) in params.snippets.iter().enumerate() {
-            let client = client.clone();
-            let project_path = project_path.clone();
-            let base_code = base_code.clone();
-            let indent = indent.clone();
+
+        if isolated {
+            // Isolated path: spawn each snippet as an independent temp-file task
+            let project_path = client.project_path().to_path_buf();
+            let base_code = lines[..params.line as usize - 1].join("\n");
+            let target_line = lines[(params.line - 1) as usize];
+            let indent_len = target_line.find(|c: char| !c.is_whitespace()).unwrap_or(0);
+            let indent = target_line[..indent_len].to_string();
+
+            for (i, snippet) in params.snippets.iter().enumerate() {
+                let client = client.clone();
+                let project_path = project_path.clone();
+                let base_code = base_code.clone();
+                let indent = indent.clone();
+                let task_manager = self.task_manager.clone();
+                let task_id = task_id.clone();
+                let snippet = snippet.clone();
+                let cancel_token = cancel_token.clone();
+
+                tokio::spawn(async move {
+                    use lean_mcp_core::task_manager::ItemStatus;
+
+                    if cancel_token.is_cancelled() {
+                        return;
+                    }
+
+                    let result = crate::tools::multi_attempt::run_snippet_isolated(
+                        client.as_ref(),
+                        &project_path,
+                        &snippet,
+                        &base_code,
+                        &indent,
+                        timeout,
+                    )
+                    .await;
+
+                    task_manager
+                        .update_item(&task_id, i, ItemStatus::Completed { result })
+                        .await;
+                });
+            }
+        } else {
+            // Default warm LSP path: single background task, sequential edit-and-restore
+            let file_path = params.file_path.clone();
+            let original_content = content.clone();
+            let line = params.line;
+            let snippets = params.snippets.clone();
             let task_manager = self.task_manager.clone();
-            let task_id = task_id.clone();
-            let snippet = snippet.clone();
-            let cancel_token = cancel_token.clone();
+            let task_id_clone = task_id.clone();
+
+            let line_text = lines[(line - 1) as usize];
+            let target_col = match params.column {
+                Some(c) if c > 0 => c - 1, // 1-indexed to 0-indexed
+                _ => line_text.find(|c: char| !c.is_whitespace()).unwrap_or(0) as u32,
+            };
 
             tokio::spawn(async move {
                 use lean_mcp_core::task_manager::ItemStatus;
 
-                if cancel_token.is_cancelled() {
-                    return;
+                for (i, snippet) in snippets.iter().enumerate() {
+                    if cancel_token.is_cancelled() {
+                        break;
+                    }
+
+                    let result = crate::tools::multi_attempt::run_one_snippet_warm(
+                        client.as_ref(),
+                        &file_path,
+                        &original_content,
+                        line,
+                        target_col,
+                        snippet,
+                        timeout,
+                    )
+                    .await;
+
+                    task_manager
+                        .update_item(&task_id_clone, i, ItemStatus::Completed { result })
+                        .await;
                 }
 
-                let result = crate::tools::multi_attempt::run_snippet_isolated(
-                    client.as_ref(),
-                    &project_path,
-                    &snippet,
-                    &base_code,
-                    &indent,
-                    timeout,
-                )
-                .await;
-
-                task_manager
-                    .update_item(&task_id, i, ItemStatus::Completed { result })
+                // Final restore + force reopen
+                let _ = client
+                    .update_file_content(&file_path, &original_content)
                     .await;
+                let _ = client.open_file_force(&file_path).await;
             });
         }
 

--- a/crates/lean-mcp-server/src/tools/multi_attempt.rs
+++ b/crates/lean-mcp-server/src/tools/multi_attempt.rs
@@ -362,6 +362,133 @@ async fn lsp_path(
 }
 
 // ---------------------------------------------------------------------------
+// Warm LSP single-snippet helper
+// ---------------------------------------------------------------------------
+
+/// Run a single snippet against the warm LSP using edit-and-restore.
+///
+/// This is the per-snippet body extracted from [`lsp_path`]. It:
+/// 1. Applies the snippet edit at `target_col` on `line`
+/// 2. Gets diagnostics and goals
+/// 3. Restores the original content
+///
+/// `line` is 1-indexed. `target_col` is 0-indexed.
+///
+/// On any error, returns an [`AttemptResult`] with the error captured as a
+/// diagnostic rather than propagating. This ensures the caller always gets
+/// a result to post to TaskManager.
+pub async fn run_one_snippet_warm(
+    client: &dyn LspClient,
+    file_path: &str,
+    original_content: &str,
+    line: u32,
+    target_col: u32,
+    snippet: &str,
+    timeout_secs: Option<f64>,
+) -> AttemptResult {
+    let lines: Vec<&str> = original_content.lines().collect();
+    let line_text = if (line as usize) <= lines.len() && line > 0 {
+        lines[(line - 1) as usize]
+    } else {
+        ""
+    };
+
+    let lsp_work = async {
+        let (snippet_str, change, goal_line, goal_column) =
+            prepare_edit(line_text, target_col, snippet, lines.len(), line);
+
+        // Apply the edit
+        client
+            .update_file(file_path, vec![change])
+            .await
+            .map_err(|e| LeanToolError::LspError {
+                operation: "update_file".into(),
+                message: e.to_string(),
+            })?;
+
+        // Get diagnostics
+        let raw_diags = client
+            .get_diagnostics(file_path, None, None, Some(15.0))
+            .await
+            .map_err(|e| LeanToolError::LspError {
+                operation: "get_diagnostics".into(),
+                message: e.to_string(),
+            })?;
+
+        let all_diags = raw_diags
+            .get("diagnostics")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        let filtered = filter_diagnostics_by_line_range(&all_diags, line - 1, goal_line);
+        let diagnostics = to_diagnostic_messages(&filtered);
+
+        // Get goals
+        let goal_result = client
+            .get_goal(file_path, goal_line, goal_column)
+            .await
+            .map_err(|e| LeanToolError::LspError {
+                operation: "get_goal".into(),
+                message: e.to_string(),
+            })?;
+
+        let goals = extract_goals_list(goal_result.as_ref());
+
+        Ok::<AttemptResult, LeanToolError>(AttemptResult {
+            snippet: snippet_str,
+            goals,
+            diagnostics,
+            timed_out: false,
+        })
+    };
+
+    // Apply per-snippet timeout if configured
+    let result: Result<AttemptResult, LeanToolError> = if let Some(secs) = timeout_secs {
+        let snippet_str = snippet.trim_end_matches('\n');
+        match tokio::time::timeout(std::time::Duration::from_secs_f64(secs), lsp_work).await {
+            Ok(r) => r,
+            Err(_) => Ok(AttemptResult {
+                snippet: snippet_str.to_string(),
+                goals: Vec::new(),
+                diagnostics: vec![DiagnosticMessage {
+                    severity: "warning".to_string(),
+                    message: format!("Tactic timed out after {secs}s"),
+                    line: 0,
+                    column: 0,
+                }],
+                timed_out: true,
+            }),
+        }
+    } else {
+        lsp_work.await
+    };
+
+    // Always restore original content after this snippet
+    let _ = client
+        .update_file_content(file_path, original_content)
+        .await;
+
+    match result {
+        Ok(r) => r,
+        Err(e) => {
+            let snippet_str = snippet.trim_end_matches('\n');
+            AttemptResult {
+                snippet: snippet_str.to_string(),
+                goals: Vec::new(),
+                diagnostics: vec![DiagnosticMessage {
+                    severity: "error".to_string(),
+                    message: e.to_string(),
+                    line: 0,
+                    column: 0,
+                }],
+                timed_out: false,
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Parallel path (run_code semantics)
 // ---------------------------------------------------------------------------
 
@@ -2666,6 +2793,293 @@ mod tests {
         assert!(
             !json_val.as_object().unwrap().contains_key("timed_out"),
             "timed_out=false should be omitted from serialized JSON"
+        );
+    }
+
+    // ========================================================================
+    // run_one_snippet_warm tests (Closes #100)
+    // ========================================================================
+
+    // ---- run_one_snippet_warm: returns goals ----
+
+    #[tokio::test]
+    async fn run_one_snippet_warm_returns_goals() {
+        let client = MockMultiAttemptClient::new("theorem foo : True := by\n  sorry").with_goal(
+            1,
+            6,
+            Some(json!({"goals": ["|- True"]})),
+        );
+
+        let result = run_one_snippet_warm(
+            &client,
+            "Main.lean",
+            "theorem foo : True := by\n  sorry",
+            2, // line (1-indexed)
+            2, // target_col (0-indexed: first non-ws on "  sorry")
+            "simp",
+            None,
+        )
+        .await;
+
+        assert_eq!(result.snippet, "simp");
+        assert_eq!(result.goals, vec!["|- True"]);
+        assert!(result.diagnostics.is_empty());
+        assert!(!result.timed_out);
+    }
+
+    // ---- run_one_snippet_warm: restores original content ----
+
+    #[tokio::test]
+    async fn run_one_snippet_warm_restores_content() {
+        let original = "theorem foo : True := by\n  sorry";
+        let client = MockMultiAttemptClient::new(original);
+
+        let _ = run_one_snippet_warm(&client, "Main.lean", original, 2, 2, "simp", None).await;
+
+        let restored = client.current_content.lock().unwrap().clone();
+        assert_eq!(restored, original, "original content must be restored");
+    }
+
+    // ---- run_one_snippet_warm: timeout produces timed_out result ----
+
+    #[tokio::test]
+    async fn run_one_snippet_warm_timeout() {
+        let client = MockTimeoutClient::new(
+            PathBuf::from("/test/project"),
+            "theorem foo : True := by\n  sorry",
+        )
+        .with_diagnostics_delay(std::time::Duration::from_secs(5));
+
+        let result = run_one_snippet_warm(
+            &client,
+            "Main.lean",
+            "theorem foo : True := by\n  sorry",
+            2,
+            2,
+            "exact?",
+            Some(0.1), // 100ms timeout, diagnostics takes 5s
+        )
+        .await;
+
+        assert!(result.timed_out, "snippet should be marked timed_out");
+        assert!(result.goals.is_empty());
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.diagnostics[0].severity, "warning");
+        assert!(result.diagnostics[0].message.contains("timed out"));
+        assert_eq!(result.snippet, "exact?");
+    }
+
+    // ---- run_one_snippet_warm: error returns diagnostic (not panic) ----
+
+    /// Mock client where update_file fails.
+    struct MockUpdateFileErrorClient {
+        project: PathBuf,
+        current_content: Mutex<String>,
+    }
+
+    impl MockUpdateFileErrorClient {
+        fn new() -> Self {
+            Self {
+                project: PathBuf::from("/test/project"),
+                current_content: Mutex::new(String::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LspClient for MockUpdateFileErrorClient {
+        fn project_path(&self) -> &Path {
+            &self.project
+        }
+        async fn open_file(&self, _p: &str) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+        async fn open_file_force(
+            &self,
+            _p: &str,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+        async fn get_file_content(
+            &self,
+            _p: &str,
+        ) -> Result<String, lean_lsp_client::client::LspClientError> {
+            Ok("theorem foo : True := by\n  sorry".to_string())
+        }
+        async fn update_file(
+            &self,
+            _p: &str,
+            _c: Vec<Value>,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Err(lean_lsp_client::client::LspClientError::FileNotOpen(
+                "update_file failed".to_string(),
+            ))
+        }
+        async fn update_file_content(
+            &self,
+            _p: &str,
+            content: &str,
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            *self.current_content.lock().unwrap() = content.to_string();
+            Ok(())
+        }
+        async fn close_files(
+            &self,
+            _p: &[String],
+        ) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+        async fn get_diagnostics(
+            &self,
+            _p: &str,
+            _sl: Option<u32>,
+            _el: Option<u32>,
+            _t: Option<f64>,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({"diagnostics": [], "success": true}))
+        }
+        async fn get_interactive_diagnostics(
+            &self,
+            _p: &str,
+            _sl: Option<u32>,
+            _el: Option<u32>,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_goal(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(None)
+        }
+        async fn get_term_goal(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(None)
+        }
+        async fn get_hover(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(None)
+        }
+        async fn get_completions(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_declarations(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_references(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+            _d: bool,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_document_symbols(
+            &self,
+            _p: &str,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_code_actions(
+            &self,
+            _p: &str,
+            _sl: u32,
+            _sc: u32,
+            _el: u32,
+            _ec: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_code_action_resolve(
+            &self,
+            _a: Value,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({}))
+        }
+        async fn get_widgets(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+        ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+            Ok(vec![])
+        }
+        async fn get_widget_source(
+            &self,
+            _p: &str,
+            _l: u32,
+            _c: u32,
+            _h: &str,
+        ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+            Ok(json!({}))
+        }
+        async fn shutdown(&self) -> Result<(), lean_lsp_client::client::LspClientError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn run_one_snippet_warm_error_returns_diagnostic() {
+        let client = MockUpdateFileErrorClient::new();
+
+        let result = run_one_snippet_warm(
+            &client,
+            "Main.lean",
+            "theorem foo : True := by\n  sorry",
+            2,
+            2,
+            "simp",
+            None,
+        )
+        .await;
+
+        // Should not panic; error captured as diagnostic
+        assert_eq!(result.snippet, "simp");
+        assert!(result.goals.is_empty());
+        assert!(!result.diagnostics.is_empty());
+        assert_eq!(result.diagnostics[0].severity, "error");
+        assert!(
+            result.diagnostics[0].message.contains("update_file"),
+            "error message should mention the failing operation: {}",
+            result.diagnostics[0].message
+        );
+        assert!(!result.timed_out);
+    }
+
+    // ---- run_one_snippet_warm: content restored even on error ----
+
+    #[tokio::test]
+    async fn run_one_snippet_warm_restores_on_error() {
+        let original = "theorem foo : True := by\n  sorry";
+        let client = MockUpdateFileErrorClient::new();
+
+        let _ = run_one_snippet_warm(&client, "Main.lean", original, 2, 2, "simp", None).await;
+
+        let restored = client.current_content.lock().unwrap().clone();
+        assert_eq!(
+            restored, original,
+            "original content must be restored even on error"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Default `lean_multi_attempt_async` to use warm LSP** (sequential edit-and-restore in a single background task) instead of creating independent temp files per snippet. This eliminates per-snippet import re-elaboration, making Mathlib-heavy projects viable (~1s vs ~120s+ per snippet).
- **Add `isolated` parameter** (`isolated=true`) to opt into the old temp-file behavior when full isolation is needed.
- **Extract `run_one_snippet_warm` public helper** from `lsp_path` loop body in `multi_attempt.rs` for per-snippet warm LSP execution with edit-restore and timeout support.

## Test plan

- [x] `run_one_snippet_warm_returns_goals` -- unit test returns goals via mock
- [x] `run_one_snippet_warm_restores_content` -- verifies original content restored after snippet
- [x] `run_one_snippet_warm_timeout` -- mock with slow diagnostics produces `timed_out: true`
- [x] `run_one_snippet_warm_error_returns_diagnostic` -- failing `update_file` captured as diagnostic (no panic/propagation)
- [x] `run_one_snippet_warm_restores_on_error` -- content restored even when edit fails
- [x] All 755 existing tests still pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean

Closes #100