### PR TITLE
fix: warn when diagnostics may be unreliable due to stale oleans

### DIFF
--- a/crates/lean-mcp-core/benches/core_bench.rs
+++ b/crates/lean-mcp-core/benches/core_bench.rs
@@ -56,6 +56,8 @@ fn bench_diagnostics_result_roundtrip(c: &mut Criterion) {
             },
         ],
         failed_dependencies: vec!["Mathlib.Tactic".into(), "Mathlib.Data.Nat.Basic".into()],
+        stale_olean_warning: None,
+        stale_files: Vec::new(),
     };
     let json = serde_json::to_string(&dr).unwrap();
 

--- a/crates/lean-mcp-core/src/file_utils.rs
+++ b/crates/lean-mcp-core/src/file_utils.rs
@@ -110,6 +110,98 @@ pub fn valid_lean_project_path(path: &Path) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// Stale olean detection
+// ---------------------------------------------------------------------------
+
+/// Check whether a single source file's olean is stale (source newer than olean).
+///
+/// Returns `true` when the source file exists and either:
+/// - No corresponding `.olean` file exists in the build directory, or
+/// - The source file's mtime is newer than the olean's mtime.
+///
+/// Returns `false` when the source file doesn't exist or mtimes can't be read.
+fn is_olean_stale(project_path: &Path, build_lib: &Path, rel_lean: &str) -> bool {
+    let source = project_path.join(rel_lean);
+    let olean = build_lib.join(Path::new(rel_lean).with_extension("olean"));
+
+    let source_mtime = match source.metadata().and_then(|m| m.modified()) {
+        Ok(t) => t,
+        Err(_) => return false, // Can't read source => assume not stale
+    };
+
+    if !olean.exists() {
+        return true; // Never built
+    }
+
+    let olean_mtime = match olean.metadata().and_then(|m| m.modified()) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+
+    source_mtime > olean_mtime
+}
+
+/// Check if a file or its direct imports have stale oleans.
+///
+/// Reads the source file, parses its `import` lines, and checks whether the
+/// target file and each imported module have an olean that is older than the
+/// corresponding source. Returns a list of relative paths whose oleans are
+/// stale.
+///
+/// This is an O(imports) check: it reads one file and performs a handful of
+/// mtime comparisons, making it safe to call on every diagnostic request.
+pub fn check_stale_imports(project_path: &Path, file_path: &str) -> Vec<String> {
+    let abs_path = project_path.join(file_path);
+    let content = match std::fs::read_to_string(&abs_path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+
+    let build_lib = project_path.join(".lake").join("build").join("lib");
+    if !build_lib.exists() {
+        return vec![]; // No build dir = never built, can't check
+    }
+
+    let mut stale = Vec::new();
+
+    // Check the target file itself
+    if is_olean_stale(project_path, &build_lib, file_path) {
+        stale.push(file_path.to_string());
+    }
+
+    // Parse import lines and check each
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Skip comments and blank lines within the import section
+        if trimmed.is_empty() || trimmed.starts_with("--") || trimmed.starts_with("/-") {
+            continue;
+        }
+
+        // Check for import statements
+        if !trimmed.starts_with("import ") && !trimmed.starts_with("public import ") {
+            // Past the import section (Lean imports must appear at the top)
+            break;
+        }
+
+        // Extract module name: "import Foo.Bar" or "public import Foo.Bar"
+        let module = trimmed
+            .trim_start_matches("public ")
+            .trim_start_matches("import ")
+            .trim();
+
+        // Convert module name to file path: Foo.Bar -> Foo/Bar.lean
+        let rel_path = module.replace('.', "/") + ".lean";
+
+        if is_olean_stale(project_path, &build_lib, &rel_path) {
+            stale.push(rel_path);
+        }
+    }
+
+    stale
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -353,5 +445,225 @@ mod tests {
             result.unwrap().canonicalize().unwrap(),
             inner_dir.canonicalize().unwrap()
         );
+    }
+
+    // ---- is_olean_stale ----
+
+    /// Helper: create a fake project with .lake/build/lib/ directory.
+    fn setup_project_with_build(dir: &TempDir) {
+        let build_lib = dir.path().join(".lake").join("build").join("lib");
+        fs::create_dir_all(&build_lib).unwrap();
+    }
+
+    #[test]
+    fn is_olean_stale_returns_false_when_source_missing() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        assert!(!is_olean_stale(
+            dir.path(),
+            &dir.path().join(".lake/build/lib"),
+            "NonExistent.lean"
+        ));
+    }
+
+    #[test]
+    fn is_olean_stale_returns_true_when_olean_missing() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        // Create source file but no olean
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+        assert!(is_olean_stale(
+            dir.path(),
+            &dir.path().join(".lake/build/lib"),
+            "Main.lean"
+        ));
+    }
+
+    #[test]
+    fn is_olean_stale_returns_true_when_source_newer() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        let build_lib = dir.path().join(".lake/build/lib");
+
+        // Create olean first
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+        // Small delay to ensure mtime difference
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Then create source (newer)
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+
+        assert!(is_olean_stale(dir.path(), &build_lib, "Main.lean"));
+    }
+
+    #[test]
+    fn is_olean_stale_returns_false_when_olean_newer() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        let build_lib = dir.path().join(".lake/build/lib");
+
+        // Create source first
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+        // Small delay to ensure mtime difference
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Then create olean (newer)
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+
+        assert!(!is_olean_stale(dir.path(), &build_lib, "Main.lean"));
+    }
+
+    // ---- check_stale_imports ----
+
+    #[test]
+    fn check_stale_imports_no_build_dir_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        // No .lake/build/lib => can't check
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+        let result = check_stale_imports(dir.path(), "Main.lean");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn check_stale_imports_detects_stale_source() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        let build_lib = dir.path().join(".lake/build/lib");
+
+        // Create olean first
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Source is newer
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+
+        let result = check_stale_imports(dir.path(), "Main.lean");
+        assert_eq!(result, vec!["Main.lean"]);
+    }
+
+    #[test]
+    fn check_stale_imports_clean_when_olean_newer() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        let build_lib = dir.path().join(".lake/build/lib");
+
+        // Source first
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Olean newer
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+
+        let result = check_stale_imports(dir.path(), "Main.lean");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn check_stale_imports_detects_stale_import() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        let build_lib = dir.path().join(".lake/build/lib");
+
+        // Target file is up to date
+        fs::write(
+            dir.path().join("Main.lean"),
+            "import Foo.Bar\n\ndef main := 0",
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+
+        // Imported module's source dir
+        let foo_dir = dir.path().join("Foo");
+        fs::create_dir_all(&foo_dir).unwrap();
+        let foo_build_dir = build_lib.join("Foo");
+        fs::create_dir_all(&foo_build_dir).unwrap();
+
+        // Import's olean is stale (olean first, then source)
+        fs::write(foo_build_dir.join("Bar.olean"), "olean").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(foo_dir.join("Bar.lean"), "-- bar").unwrap();
+
+        let result = check_stale_imports(dir.path(), "Main.lean");
+        assert_eq!(result, vec!["Foo/Bar.lean"]);
+    }
+
+    #[test]
+    fn check_stale_imports_missing_olean_is_stale() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+
+        // Source exists but no olean at all
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+
+        let result = check_stale_imports(dir.path(), "Main.lean");
+        assert_eq!(result, vec!["Main.lean"]);
+    }
+
+    #[test]
+    fn check_stale_imports_missing_source_file_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        // File doesn't exist => can't read, returns empty
+        let result = check_stale_imports(dir.path(), "NonExistent.lean");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn check_stale_imports_parses_public_import() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        let build_lib = dir.path().join(".lake/build/lib");
+
+        // Target file with public import
+        fs::write(
+            dir.path().join("Main.lean"),
+            "public import Foo.Bar\n\ndef main := 0",
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+
+        // Import source with no olean
+        let foo_dir = dir.path().join("Foo");
+        fs::create_dir_all(&foo_dir).unwrap();
+        fs::write(foo_dir.join("Bar.lean"), "-- bar").unwrap();
+
+        let result = check_stale_imports(dir.path(), "Main.lean");
+        assert_eq!(result, vec!["Foo/Bar.lean"]);
+    }
+
+    #[test]
+    fn check_stale_imports_stops_at_non_import_line() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        let build_lib = dir.path().join(".lake/build/lib");
+
+        // Non-import code appears before "import" deeper in the file
+        let content = "def foo := 0\nimport Fake.Module\n";
+        fs::write(dir.path().join("Main.lean"), content).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+
+        // If Fake.Module source existed, it should NOT be checked
+        // because we stopped parsing imports at "def foo"
+        let result = check_stale_imports(dir.path(), "Main.lean");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn check_stale_imports_skips_comments_in_import_section() {
+        let dir = TempDir::new().unwrap();
+        setup_project_with_build(&dir);
+        let build_lib = dir.path().join(".lake/build/lib");
+
+        let content = "-- A comment\nimport Foo.Bar\n\ndef main := 0";
+        fs::write(dir.path().join("Main.lean"), content).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+
+        // Foo.Bar source with no olean => stale
+        let foo_dir = dir.path().join("Foo");
+        fs::create_dir_all(&foo_dir).unwrap();
+        fs::write(foo_dir.join("Bar.lean"), "-- bar").unwrap();
+
+        let result = check_stale_imports(dir.path(), "Main.lean");
+        assert_eq!(result, vec!["Foo/Bar.lean"]);
     }
 }

--- a/crates/lean-mcp-core/src/models.rs
+++ b/crates/lean-mcp-core/src/models.rs
@@ -270,6 +270,13 @@ pub struct DiagnosticsResult {
     /// File paths of dependencies that failed to build.
     #[serde(default)]
     pub failed_dependencies: Vec<String>,
+    /// Warning when source files are newer than their cached oleans.
+    /// The LSP uses oleans for imports, so diagnostics may be unreliable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stale_olean_warning: Option<String>,
+    /// Relative paths of source files with stale oleans.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stale_files: Vec<String>,
 }
 
 /// Wrapper for completions list.
@@ -666,12 +673,51 @@ mod tests {
                 column: 5,
             }],
             failed_dependencies: vec!["Mathlib.Tactic".into()],
+            stale_olean_warning: None,
+            stale_files: Vec::new(),
         };
         let json = serde_json::to_string(&dr).unwrap();
         let dr2: DiagnosticsResult = serde_json::from_str(&json).unwrap();
         assert!(!dr2.success);
         assert_eq!(dr2.items.len(), 1);
         assert_eq!(dr2.failed_dependencies, vec!["Mathlib.Tactic"]);
+        assert!(dr2.stale_olean_warning.is_none());
+        assert!(dr2.stale_files.is_empty());
+    }
+
+    #[test]
+    fn round_trip_diagnostics_result_with_stale_oleans() {
+        let dr = DiagnosticsResult {
+            success: true,
+            items: vec![],
+            failed_dependencies: vec![],
+            stale_olean_warning: Some(
+                "WARNING: 2 source file(s) are newer than their oleans".into(),
+            ),
+            stale_files: vec!["Foo/Bar.lean".into(), "Main.lean".into()],
+        };
+        let json = serde_json::to_string(&dr).unwrap();
+        let dr2: DiagnosticsResult = serde_json::from_str(&json).unwrap();
+        assert!(dr2.success);
+        assert_eq!(
+            dr2.stale_olean_warning.as_deref(),
+            Some("WARNING: 2 source file(s) are newer than their oleans")
+        );
+        assert_eq!(dr2.stale_files, vec!["Foo/Bar.lean", "Main.lean"]);
+    }
+
+    #[test]
+    fn diagnostics_result_stale_fields_omitted_when_empty() {
+        let dr = DiagnosticsResult {
+            success: true,
+            items: vec![],
+            failed_dependencies: vec![],
+            stale_olean_warning: None,
+            stale_files: Vec::new(),
+        };
+        let v: Value = serde_json::to_value(&dr).unwrap();
+        assert!(!v.as_object().unwrap().contains_key("stale_olean_warning"));
+        assert!(!v.as_object().unwrap().contains_key("stale_files"));
     }
 
     #[test]

--- a/crates/lean-mcp-server/src/server.rs
+++ b/crates/lean-mcp-server/src/server.rs
@@ -648,8 +648,10 @@ impl AppContext {
         Parameters(params): Parameters<DiagnosticParams>,
     ) -> Result<String, String> {
         let client = self.client_for_file(&params.file_path).await?;
+        let project_path = self.resolve_project_path(Some(&params.file_path))?;
         tools::diagnostics::handle_diagnostics(
             client.as_ref(),
+            &project_path,
             &params.file_path,
             params.start_line,
             params.end_line,

--- a/crates/lean-mcp-server/src/tools/batch.rs
+++ b/crates/lean-mcp-server/src/tools/batch.rs
@@ -308,8 +308,10 @@ async fn dispatch_inner(
         "lean_diagnostic_messages" => {
             let a: DiagnosticsArgs = deser(args)?;
             let c = require_client(client)?;
+            let pp = project_path.unwrap_or(Path::new("."));
             let r = super::diagnostics::handle_diagnostics(
                 c,
+                pp,
                 &a.file_path,
                 a.start_line,
                 a.end_line,

--- a/crates/lean-mcp-server/src/tools/diagnostics.rs
+++ b/crates/lean-mcp-server/src/tools/diagnostics.rs
@@ -4,9 +4,12 @@
 //! file. Supports line-range filtering, declaration-name filtering, severity
 //! filtering, interactive mode, and build-error extraction.
 
+use std::path::Path;
+
 use lean_lsp_client::client::LspClient;
 use lean_lsp_client::types::severity;
 use lean_mcp_core::error::LeanToolError;
+use lean_mcp_core::file_utils::check_stale_imports;
 use lean_mcp_core::models::{DiagnosticMessage, DiagnosticsResult, InteractiveDiagnosticsResult};
 use regex::Regex;
 use serde_json::Value;
@@ -113,6 +116,8 @@ fn process_diagnostics(
         success: build_success,
         items,
         failed_dependencies: failed_deps,
+        stale_olean_warning: None,
+        stale_files: Vec::new(),
     }
 }
 
@@ -123,12 +128,20 @@ fn process_diagnostics(
 /// Handle a `lean_diagnostic_messages` tool call.
 ///
 /// Supports line-range filtering, declaration-name filtering, severity
-/// filtering, interactive mode, and build-error extraction.
+/// filtering, interactive mode, build-error extraction, and stale olean
+/// detection.
 ///
 /// `start_line` and `end_line` are **1-indexed** (matching the MCP tool
 /// interface). They are converted to 0-indexed for LSP calls internally.
+///
+/// When diagnostics contain no errors, the handler checks whether the target
+/// file or its direct imports have oleans older than their source. If stale
+/// oleans are found, a warning is included in the result so the caller knows
+/// that "clean" diagnostics may be unreliable.
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_diagnostics(
     client: &dyn LspClient,
+    project_path: &Path,
     file_path: &str,
     start_line: Option<u32>,
     end_line: Option<u32>,
@@ -190,7 +203,25 @@ pub async fn handle_diagnostics(
         .unwrap_or_default();
     let build_success = raw.get("success").and_then(Value::as_bool).unwrap_or(true);
 
-    let result = process_diagnostics(&diagnostics_arr, build_success, severity_filter);
+    let mut result = process_diagnostics(&diagnostics_arr, build_success, severity_filter);
+
+    // 6. Stale olean check: only when no errors reported (the dangerous case).
+    let has_errors = result.items.iter().any(|item| item.severity == "error");
+    if !has_errors {
+        let stale = check_stale_imports(project_path, file_path);
+        if !stale.is_empty() {
+            let warning = format!(
+                "WARNING: {} source file(s) are newer than their oleans (e.g., {}). \
+                 Diagnostics may be unreliable — the LSP uses cached oleans for imports. \
+                 Call `lean_build` to rebuild, then re-check diagnostics.",
+                stale.len(),
+                stale.iter().take(3).cloned().collect::<Vec<_>>().join(", ")
+            );
+            result.stale_olean_warning = Some(warning);
+            result.stale_files = stale;
+        }
+    }
+
     serde_json::to_value(&result).map_err(|e| LeanToolError::Other(e.to_string()))
 }
 
@@ -546,9 +577,18 @@ mod tests {
             false,
         );
 
-        let result = handle_diagnostics(&client, "Main.lean", None, None, None, false, None)
-            .await
-            .unwrap();
+        let result = handle_diagnostics(
+            &client,
+            Path::new("/test/project"),
+            "Main.lean",
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
 
         let dr: DiagnosticsResult = serde_json::from_value(result).unwrap();
         assert!(!dr.success);
@@ -564,9 +604,18 @@ mod tests {
             vec![json!({"severity": 1, "message": {"tag": "text", "text": "err"}})];
         let client = MockDiagClient::new().with_interactive(interactive_diags.clone());
 
-        let result = handle_diagnostics(&client, "Main.lean", None, None, None, true, None)
-            .await
-            .unwrap();
+        let result = handle_diagnostics(
+            &client,
+            Path::new("/test/project"),
+            "Main.lean",
+            None,
+            None,
+            None,
+            true,
+            None,
+        )
+        .await
+        .unwrap();
 
         let ir: InteractiveDiagnosticsResult = serde_json::from_value(result).unwrap();
         assert_eq!(ir.diagnostics.len(), 1);
@@ -596,10 +645,18 @@ mod tests {
                 true,
             );
 
-        let result =
-            handle_diagnostics(&client, "Main.lean", None, None, Some("myThm"), false, None)
-                .await
-                .unwrap();
+        let result = handle_diagnostics(
+            &client,
+            Path::new("/test/project"),
+            "Main.lean",
+            None,
+            None,
+            Some("myThm"),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
 
         let dr: DiagnosticsResult = serde_json::from_value(result).unwrap();
         assert!(dr.success);
@@ -612,6 +669,7 @@ mod tests {
 
         let err = handle_diagnostics(
             &client,
+            Path::new("/test/project"),
             "Main.lean",
             None,
             None,
@@ -634,13 +692,139 @@ mod tests {
     async fn diagnostics_empty_file_returns_success() {
         let client = MockDiagClient::new();
 
-        let result = handle_diagnostics(&client, "Empty.lean", None, None, None, false, None)
-            .await
-            .unwrap();
+        let result = handle_diagnostics(
+            &client,
+            Path::new("/test/project"),
+            "Empty.lean",
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
 
         let dr: DiagnosticsResult = serde_json::from_value(result).unwrap();
         assert!(dr.success);
         assert!(dr.items.is_empty());
         assert!(dr.failed_dependencies.is_empty());
+    }
+
+    // ---- stale olean integration tests ----
+
+    #[tokio::test]
+    async fn diagnostics_includes_stale_warning_when_no_errors() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let build_lib = dir.path().join(".lake/build/lib");
+        fs::create_dir_all(&build_lib).unwrap();
+
+        // Create olean first, then source (source newer => stale)
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+
+        let client = MockDiagClient::new(); // returns empty diagnostics (success=true)
+
+        let result = handle_diagnostics(
+            &client,
+            dir.path(),
+            "Main.lean",
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let dr: DiagnosticsResult = serde_json::from_value(result).unwrap();
+        assert!(dr.success);
+        assert!(dr.stale_olean_warning.is_some());
+        assert!(dr.stale_olean_warning.unwrap().contains("WARNING"));
+        assert_eq!(dr.stale_files, vec!["Main.lean"]);
+    }
+
+    #[tokio::test]
+    async fn diagnostics_no_stale_warning_when_errors_present() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let build_lib = dir.path().join(".lake/build/lib");
+        fs::create_dir_all(&build_lib).unwrap();
+
+        // Stale olean
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+
+        // Client returns an error diagnostic
+        let client = MockDiagClient::new().with_diagnostics(
+            vec![json!({
+                "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 5}},
+                "severity": 1,
+                "message": "unknown identifier"
+            })],
+            false,
+        );
+
+        let result = handle_diagnostics(
+            &client,
+            dir.path(),
+            "Main.lean",
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let dr: DiagnosticsResult = serde_json::from_value(result).unwrap();
+        assert!(!dr.success);
+        // When errors are present, stale check is skipped
+        assert!(dr.stale_olean_warning.is_none());
+        assert!(dr.stale_files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn diagnostics_no_stale_warning_when_oleans_fresh() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let build_lib = dir.path().join(".lake/build/lib");
+        fs::create_dir_all(&build_lib).unwrap();
+
+        // Source first, then olean (olean newer => fresh)
+        fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+
+        let client = MockDiagClient::new();
+
+        let result = handle_diagnostics(
+            &client,
+            dir.path(),
+            "Main.lean",
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let dr: DiagnosticsResult = serde_json::from_value(result).unwrap();
+        assert!(dr.success);
+        assert!(dr.stale_olean_warning.is_none());
+        assert!(dr.stale_files.is_empty());
     }
 }


### PR DESCRIPTION
Closes #107

## Summary
- Adds `check_stale_imports` and `is_olean_stale` functions to `lean-mcp-core/src/file_utils.rs` that detect when source files are newer than their cached oleans
- Adds `stale_olean_warning` and `stale_files` fields to `DiagnosticsResult` model (omitted from JSON when empty)
- Integrates stale olean check into `handle_diagnostics` -- only triggers when diagnostics report **zero errors** (the dangerous "clean but lying" case)
- The check is O(imports): reads the target file, parses its import lines, and does a handful of mtime comparisons -- safe for every diagnostic call

## Test plan
- [x] `is_olean_stale` unit tests: missing source, missing olean, source newer, olean newer
- [x] `check_stale_imports` unit tests: no build dir, stale source, clean oleans, stale import, missing olean, public imports, stops at non-import lines, skips comments
- [x] `DiagnosticsResult` model tests: round-trip with stale fields, empty fields omitted from JSON
- [x] Integration tests with mock LSP + real temp directories: stale warning present when no errors, skipped when errors present, absent when oleans fresh
- [x] All quality gates: `cargo test --all`, `cargo fmt`, `cargo clippy -D warnings`, `cargo doc -D warnings`