### PR TITLE
fix: move temp snippet files to .lake/_mcp/ to avoid git pollution

### DIFF
--- a/crates/lean-mcp-server/src/tools/multi_attempt.rs
+++ b/crates/lean-mcp-server/src/tools/multi_attempt.rs
@@ -530,8 +530,11 @@ pub async fn run_snippet_isolated(
 
     let base_line_count = base_code.lines().count();
 
-    let rel_path = format!("_mcp_attempt_{}.lean", Uuid::new_v4().as_simple());
-    let abs_path = project_path.join(&rel_path);
+    let mcp_dir = project_path.join(".lake").join("_mcp");
+    std::fs::create_dir_all(&mcp_dir).ok(); // Ensure directory exists
+    let filename = format!("_mcp_attempt_{}.lean", Uuid::new_v4().as_simple());
+    let abs_path = mcp_dir.join(&filename);
+    let rel_path = format!(".lake/_mcp/{filename}");
 
     // Write temp file
     if let Err(e) = std::fs::write(&abs_path, &code) {
@@ -1650,12 +1653,26 @@ mod tests {
             .await
             .unwrap();
 
-        let remaining: Vec<_> = std::fs::read_dir(dir.path())
+        // Check .lake/_mcp/ directory for leftover temp files.
+        let mcp_dir = dir.path().join(".lake").join("_mcp");
+        if mcp_dir.exists() {
+            let remaining: Vec<_> = std::fs::read_dir(&mcp_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().starts_with("_mcp_attempt_"))
+                .collect();
+            assert!(remaining.is_empty(), "temp files were not cleaned up");
+        }
+        // Also verify no temp files in project root.
+        let root_remaining: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()
             .filter_map(|e| e.ok())
             .filter(|e| e.file_name().to_string_lossy().starts_with("_mcp_attempt_"))
             .collect();
-        assert!(remaining.is_empty(), "temp files were not cleaned up");
+        assert!(
+            root_remaining.is_empty(),
+            "temp files should not be in project root"
+        );
     }
 
     // ---- Parallel: close_files called for each snippet ----
@@ -1681,8 +1698,51 @@ mod tests {
         );
         for path in closed.iter() {
             assert!(
-                path.starts_with("_mcp_attempt_"),
-                "closed path should be a temp file: {path}"
+                path.starts_with(".lake/_mcp/_mcp_attempt_"),
+                "closed path should be a temp file in .lake/_mcp/: {path}"
+            );
+        }
+    }
+
+    // ---- Parallel: temp files are in .lake/_mcp/ not project root ----
+
+    #[tokio::test]
+    async fn parallel_temp_files_in_lake_mcp_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = MockParallelClient::new(
+            dir.path().to_path_buf(),
+            "theorem foo : True := by\n  sorry",
+        );
+
+        let snippets = vec!["simp".to_string()];
+        let _ = handle_multi_attempt_parallel(&client, dir.path(), "Main.lean", 2, &snippets, None)
+            .await
+            .unwrap();
+
+        // The .lake/_mcp/ directory should have been created (even if files are cleaned up)
+        let mcp_dir = dir.path().join(".lake").join("_mcp");
+        assert!(
+            mcp_dir.exists(),
+            ".lake/_mcp/ directory should be created for temp files"
+        );
+
+        // Verify no temp files leaked to project root
+        let root_remaining: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("_mcp_attempt_"))
+            .collect();
+        assert!(
+            root_remaining.is_empty(),
+            "temp files should not be in project root"
+        );
+
+        // Verify close_files paths have the new prefix
+        let closed = client.close_called.lock().unwrap();
+        for path in closed.iter() {
+            assert!(
+                path.starts_with(".lake/_mcp/"),
+                "closed path should be in .lake/_mcp/: {path}"
             );
         }
     }
@@ -1973,8 +2033,8 @@ mod tests {
             p: &str,
         ) -> Result<String, lean_lsp_client::client::LspClientError> {
             // Simulate cold LSP: if the file hasn't been opened, fail.
-            // Temp files (starting with _mcp_attempt_) are always "open".
-            if !p.starts_with("_mcp_attempt_") {
+            // Temp files (in .lake/_mcp/_mcp_attempt_) are always "open".
+            if !p.starts_with(".lake/_mcp/_mcp_attempt_") {
                 let calls = self.open_file_calls.lock().unwrap();
                 if !calls.contains(&p.to_string()) {
                     return Err(lean_lsp_client::client::LspClientError::FileNotOpen(
@@ -2166,7 +2226,7 @@ mod tests {
         }
         async fn open_file(&self, p: &str) -> Result<(), lean_lsp_client::client::LspClientError> {
             // Temp files succeed, source file fails
-            if !p.starts_with("_mcp_attempt_") {
+            if !p.starts_with(".lake/_mcp/_mcp_attempt_") {
                 return Err(lean_lsp_client::client::LspClientError::FileNotOpen(
                     format!("Cannot open file: {p}"),
                 ));
@@ -2653,16 +2713,19 @@ mod tests {
         .await
         .unwrap();
 
-        // Verify temp files were cleaned up
-        let remaining: Vec<_> = std::fs::read_dir(dir.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_name().to_string_lossy().starts_with("_mcp_attempt_"))
-            .collect();
-        assert!(
-            remaining.is_empty(),
-            "temp files should be cleaned up even on timeout"
-        );
+        // Verify temp files were cleaned up from .lake/_mcp/
+        let mcp_dir = dir.path().join(".lake").join("_mcp");
+        if mcp_dir.exists() {
+            let remaining: Vec<_> = std::fs::read_dir(&mcp_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().starts_with("_mcp_attempt_"))
+                .collect();
+            assert!(
+                remaining.is_empty(),
+                "temp files should be cleaned up even on timeout"
+            );
+        }
 
         // Verify close_files was called
         let closed = client.close_called.lock().unwrap();

--- a/crates/lean-mcp-server/src/tools/run_code.rs
+++ b/crates/lean-mcp-server/src/tools/run_code.rs
@@ -64,9 +64,13 @@ pub async fn handle_run_code(
     project_path: &Path,
     code: &str,
 ) -> Result<RunResult, LeanToolError> {
-    // 1. Generate UUID-based temp filename.
-    let rel_path = format!("_mcp_snippet_{}.lean", Uuid::new_v4().as_simple());
-    let abs_path = project_path.join(&rel_path);
+    // 1. Generate UUID-based temp filename inside .lake/_mcp/ to avoid git pollution.
+    let mcp_dir = project_path.join(".lake").join("_mcp");
+    std::fs::create_dir_all(&mcp_dir)
+        .map_err(|e| LeanToolError::Other(format!("Error creating .lake/_mcp dir: {e}")))?;
+    let filename = format!("_mcp_snippet_{}.lean", Uuid::new_v4().as_simple());
+    let abs_path = mcp_dir.join(&filename);
+    let rel_path = format!(".lake/_mcp/{filename}");
 
     // 2. Write code to the temp file.
     std::fs::write(&abs_path, code)
@@ -360,13 +364,210 @@ mod tests {
             .await
             .unwrap();
 
-        // No _mcp_snippet_*.lean files should remain.
-        let remaining: Vec<_> = std::fs::read_dir(dir.path())
+        // No _mcp_snippet_*.lean files should remain in .lake/_mcp/.
+        let mcp_dir = dir.path().join(".lake").join("_mcp");
+        if mcp_dir.exists() {
+            let remaining: Vec<_> = std::fs::read_dir(&mcp_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().starts_with("_mcp_snippet_"))
+                .collect();
+            assert!(remaining.is_empty(), "temp file was not cleaned up");
+        }
+        // Also verify no temp files leaked to project root.
+        let root_remaining: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()
             .filter_map(|e| e.ok())
             .filter(|e| e.file_name().to_string_lossy().starts_with("_mcp_snippet_"))
             .collect();
-        assert!(remaining.is_empty(), "temp file was not cleaned up");
+        assert!(
+            root_remaining.is_empty(),
+            "temp file should not be in project root"
+        );
+    }
+
+    // ---- temp files are created in .lake/_mcp/ ----
+
+    #[tokio::test]
+    async fn temp_files_in_lake_mcp_dir() {
+        let dir = TempDir::new().unwrap();
+
+        // Use a mock that tracks opened file paths.
+        struct PathTrackingClient {
+            project: PathBuf,
+            opened: std::sync::Mutex<Vec<String>>,
+        }
+
+        #[async_trait]
+        impl LspClient for PathTrackingClient {
+            fn project_path(&self) -> &Path {
+                &self.project
+            }
+            async fn open_file(
+                &self,
+                p: &str,
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                self.opened.lock().unwrap().push(p.to_string());
+                Ok(())
+            }
+            async fn open_file_force(
+                &self,
+                _p: &str,
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+            async fn get_file_content(
+                &self,
+                _p: &str,
+            ) -> Result<String, lean_lsp_client::client::LspClientError> {
+                Ok(String::new())
+            }
+            async fn update_file(
+                &self,
+                _p: &str,
+                _c: Vec<Value>,
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+            async fn update_file_content(
+                &self,
+                _p: &str,
+                _c: &str,
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+            async fn close_files(
+                &self,
+                _p: &[String],
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+            async fn get_diagnostics(
+                &self,
+                _p: &str,
+                _sl: Option<u32>,
+                _el: Option<u32>,
+                _t: Option<f64>,
+            ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+                Ok(json!({"diagnostics": [], "success": true}))
+            }
+            async fn get_interactive_diagnostics(
+                &self,
+                _p: &str,
+                _sl: Option<u32>,
+                _el: Option<u32>,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_goal(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(None)
+            }
+            async fn get_term_goal(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(None)
+            }
+            async fn get_hover(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(None)
+            }
+            async fn get_completions(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_declarations(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_references(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+                _d: bool,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_document_symbols(
+                &self,
+                _p: &str,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_code_actions(
+                &self,
+                _p: &str,
+                _sl: u32,
+                _sc: u32,
+                _el: u32,
+                _ec: u32,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_code_action_resolve(
+                &self,
+                _a: Value,
+            ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+                Ok(json!({}))
+            }
+            async fn get_widgets(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_widget_source(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+                _h: &str,
+            ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+                Ok(json!({}))
+            }
+            async fn shutdown(&self) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+        }
+
+        let client = PathTrackingClient {
+            project: dir.path().to_path_buf(),
+            opened: std::sync::Mutex::new(Vec::new()),
+        };
+
+        let _ = handle_run_code(&client, dir.path(), "#check Nat")
+            .await
+            .unwrap();
+
+        let opened = client.opened.lock().unwrap();
+        assert_eq!(opened.len(), 1);
+        assert!(
+            opened[0].starts_with(".lake/_mcp/_mcp_snippet_"),
+            "temp file should be in .lake/_mcp/, got: {}",
+            opened[0]
+        );
     }
 
     // ---- close_files is always called ----


### PR DESCRIPTION
## Summary
- Moves `_mcp_snippet_*.lean` and `_mcp_attempt_*.lean` temp files from the project root to `.lake/_mcp/`, which is already gitignored by Lake's default `.gitignore`
- Files remain within the project directory so LSP imports still resolve correctly
- Ensures `.lake/_mcp/` directory is created before writing temp files
- Updates all tests to verify temp files use the new location and don't leak to the project root

Closes #112

## Test plan
- [x] `temp_files_in_lake_mcp_dir` — verifies run_code temp files are opened with `.lake/_mcp/` prefix
- [x] `parallel_temp_files_in_lake_mcp_dir` — verifies multi_attempt temp files are in `.lake/_mcp/`
- [x] Updated `run_code_cleans_up_temp_file` — checks cleanup in `.lake/_mcp/` and no leaks to root
- [x] Updated `parallel_temp_files_cleaned_up` — checks cleanup in `.lake/_mcp/` and no leaks to root
- [x] Updated `parallel_close_files_called` — verifies close paths use new prefix
- [x] Updated `parallel_timeout_cleans_up_temp_files` — checks cleanup in new location on timeout
- [x] All 362 unit tests + 21 e2e tests pass
- [x] `cargo fmt`, `cargo clippy`, `cargo doc` all clean