### PR TITLE
feat: add criterion microbenchmarks for core hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "clap",
+ "criterion",
  "futures",
  "lean-lsp-client",
  "lean-mcp-core",

--- a/crates/lean-mcp-core/benches/core_bench.rs
+++ b/crates/lean-mcp-core/benches/core_bench.rs
@@ -1,348 +1,267 @@
-use std::collections::HashMap;
+//! Criterion microbenchmarks for lean-mcp-core hot paths.
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use lean_mcp_core::models::{
-    BuildResult, CodeAction, CodeActionEdit, CodeActionsResult, CompletionItem, CompletionsResult,
-    DiagnosticMessage, DiagnosticsResult, FileOutline, GoalState, HoverInfo, LineProfile,
-    OutlineEntry, ProofProfileResult, VerifyResult,
-};
-use lean_mcp_core::rate_limit::RateLimiter;
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use std::fs;
+use std::time::Duration;
+use tempfile::TempDir;
+
+use lean_mcp_core::file_utils::{check_stale_imports, detect_lean_project, get_relative_file_path};
+use lean_mcp_core::task_manager::{ItemStatus, TaskManager};
 
 // ---------------------------------------------------------------------------
-// Model serialization round-trips
+// detect_lean_project
 // ---------------------------------------------------------------------------
 
-fn bench_goal_state_roundtrip(c: &mut Criterion) {
-    let gs = GoalState {
-        line_context: "exact Nat.succ_pos n".into(),
-        goals: Some(vec![
-            "0 < Nat.succ n".into(),
-            "∀ (m : Nat), m < n → 0 < m".into(),
-        ]),
-        goals_before: None,
-        goals_after: None,
-    };
-    let json = serde_json::to_string(&gs).unwrap();
-
-    c.bench_function("model_goal_state_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&gs)).unwrap())
-    });
-    c.bench_function("model_goal_state_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<GoalState>(black_box(&json)).unwrap())
-    });
+/// Create a temp directory tree with a lakefile.lean marker at `depth` levels
+/// above the deepest directory. Returns `(TempDir, deepest_path)`.
+fn make_project_tree(depth: usize) -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let mut current = dir.path().to_path_buf();
+    for i in 0..depth {
+        current = current.join(format!("d{i}"));
+    }
+    fs::create_dir_all(&current).unwrap();
+    // Place marker at root
+    fs::write(dir.path().join("lakefile.lean"), "-- lakefile").unwrap();
+    (dir, current)
 }
 
-fn bench_diagnostics_result_roundtrip(c: &mut Criterion) {
-    let dr = DiagnosticsResult {
-        success: false,
-        items: vec![
-            DiagnosticMessage {
-                severity: "error".into(),
-                message: "unknown identifier 'foo'".into(),
-                line: 10,
-                column: 5,
-            },
-            DiagnosticMessage {
-                severity: "warning".into(),
-                message: "unused variable 'x'".into(),
-                line: 15,
-                column: 3,
-            },
-            DiagnosticMessage {
-                severity: "info".into(),
-                message: "declaration uses sorry".into(),
-                line: 20,
-                column: 1,
-            },
-        ],
-        failed_dependencies: vec!["Mathlib.Tactic".into(), "Mathlib.Data.Nat.Basic".into()],
-        stale_olean_warning: None,
-        stale_files: Vec::new(),
-    };
-    let json = serde_json::to_string(&dr).unwrap();
+fn bench_detect_lean_project(c: &mut Criterion) {
+    let mut group = c.benchmark_group("detect_lean_project");
 
-    c.bench_function("model_diagnostics_result_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&dr)).unwrap())
-    });
-    c.bench_function("model_diagnostics_result_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<DiagnosticsResult>(black_box(&json)).unwrap())
-    });
+    for depth in [1, 5, 10] {
+        group.bench_function(format!("depth_{depth}"), |b| {
+            b.iter_batched(
+                || make_project_tree(depth),
+                |(_dir, deepest)| {
+                    let result = detect_lean_project(black_box(&deepest));
+                    assert!(result.is_some());
+                    result
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
 }
 
-fn bench_hover_info_roundtrip(c: &mut Criterion) {
-    let hi = HoverInfo {
-        symbol: "Nat.add".into(),
-        info: "Nat → Nat → Nat\n\nAddition of natural numbers.".into(),
-        diagnostics: vec![DiagnosticMessage {
-            severity: "info".into(),
-            message: "type mismatch".into(),
-            line: 5,
-            column: 10,
-        }],
-    };
-    let json = serde_json::to_string(&hi).unwrap();
+// ---------------------------------------------------------------------------
+// get_relative_file_path
+// ---------------------------------------------------------------------------
 
-    c.bench_function("model_hover_info_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&hi)).unwrap())
+fn bench_get_relative_file_path(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get_relative_file_path");
+
+    // Absolute path under project
+    group.bench_function("absolute_under_project", |b| {
+        b.iter_batched(
+            || {
+                let dir = TempDir::new().unwrap();
+                let sub = dir.path().join("src");
+                fs::create_dir_all(&sub).unwrap();
+                let file = sub.join("Foo.lean");
+                fs::write(&file, "-- foo").unwrap();
+                let file_str = file.to_string_lossy().to_string();
+                let project = dir.path().to_path_buf();
+                (dir, project, file_str)
+            },
+            |(_dir, project, file_str)| {
+                let result = get_relative_file_path(black_box(&project), black_box(&file_str));
+                assert!(result.is_some());
+                result
+            },
+            BatchSize::SmallInput,
+        );
     });
-    c.bench_function("model_hover_info_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<HoverInfo>(black_box(&json)).unwrap())
+
+    // Relative path
+    group.bench_function("relative_path", |b| {
+        b.iter_batched(
+            || {
+                let dir = TempDir::new().unwrap();
+                fs::write(dir.path().join("Main.lean"), "-- main").unwrap();
+                let project = dir.path().to_path_buf();
+                (dir, project)
+            },
+            |(_dir, project)| {
+                let result = get_relative_file_path(black_box(&project), black_box("Main.lean"));
+                assert!(result.is_some());
+                result
+            },
+            BatchSize::SmallInput,
+        );
     });
+
+    group.finish();
 }
 
-fn bench_completions_result_roundtrip(c: &mut Criterion) {
-    let cr = CompletionsResult {
-        items: (0..20)
-            .map(|i| CompletionItem {
-                label: format!("Nat.add_comm_{i}"),
-                kind: Some("Function".into()),
-                detail: Some(format!("∀ (n m : Nat), n + m = m + n (variant {i})")),
+// ---------------------------------------------------------------------------
+// check_stale_imports
+// ---------------------------------------------------------------------------
+
+/// Create a project with N imports, where `stale_count` of them have stale oleans.
+fn make_stale_project(import_count: usize, stale_count: usize) -> (TempDir, String) {
+    let dir = TempDir::new().unwrap();
+    let build_lib = dir.path().join(".lake").join("build").join("lib");
+    fs::create_dir_all(&build_lib).unwrap();
+
+    // Build import lines
+    let mut imports = Vec::new();
+    for i in 0..import_count {
+        let mod_dir = dir.path().join(format!("Mod{i}"));
+        fs::create_dir_all(&mod_dir).unwrap();
+        let mod_build = build_lib.join(format!("Mod{i}"));
+        fs::create_dir_all(&mod_build).unwrap();
+
+        if i < stale_count {
+            // Stale: olean first, then source
+            fs::write(mod_build.join("Impl.olean"), "olean").unwrap();
+            // Ensure mtime difference
+            std::thread::sleep(Duration::from_millis(10));
+            fs::write(mod_dir.join("Impl.lean"), "-- impl").unwrap();
+        } else {
+            // Fresh: source first, then olean
+            fs::write(mod_dir.join("Impl.lean"), "-- impl").unwrap();
+            std::thread::sleep(Duration::from_millis(10));
+            fs::write(mod_build.join("Impl.olean"), "olean").unwrap();
+        }
+
+        imports.push(format!("import Mod{i}.Impl"));
+    }
+
+    // The target file
+    let content = format!("{}\n\ndef main := 0\n", imports.join("\n"));
+    fs::write(dir.path().join("Main.lean"), &content).unwrap();
+    std::thread::sleep(Duration::from_millis(10));
+    fs::write(build_lib.join("Main.olean"), "olean").unwrap();
+
+    (dir, "Main.lean".to_string())
+}
+
+fn bench_check_stale_imports(c: &mut Criterion) {
+    let mut group = c.benchmark_group("check_stale_imports");
+
+    // 5 imports, none stale
+    group.bench_function("5_imports_0_stale", |b| {
+        b.iter_batched(
+            || make_stale_project(5, 0),
+            |(dir, file)| {
+                let result = check_stale_imports(black_box(dir.path()), black_box(&file));
+                assert!(result.is_empty());
+                result
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // 5 imports, 2 stale
+    group.bench_function("5_imports_2_stale", |b| {
+        b.iter_batched(
+            || make_stale_project(5, 2),
+            |(dir, file)| {
+                let result = check_stale_imports(black_box(dir.path()), black_box(&file));
+                assert_eq!(result.len(), 2);
+                result
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // 5 imports, all stale
+    group.bench_function("5_imports_5_stale", |b| {
+        b.iter_batched(
+            || make_stale_project(5, 5),
+            |(dir, file)| {
+                let result = check_stale_imports(black_box(dir.path()), black_box(&file));
+                assert_eq!(result.len(), 5);
+                result
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// task_manager: create + poll
+// ---------------------------------------------------------------------------
+
+fn bench_task_manager_create_and_poll(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    c.bench_function("task_manager_create_and_poll", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mgr: TaskManager<String> = TaskManager::new(black_box(Duration::from_secs(60)));
+                let (id, _token) = mgr.create_task(black_box(5)).await;
+                let snap = mgr.get_task(black_box(&id)).await;
+                assert!(snap.is_some());
+                snap
             })
-            .collect(),
-    };
-    let json = serde_json::to_string(&cr).unwrap();
-
-    c.bench_function("model_completions_result_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&cr)).unwrap())
-    });
-    c.bench_function("model_completions_result_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<CompletionsResult>(black_box(&json)).unwrap())
-    });
-}
-
-fn bench_file_outline_roundtrip(c: &mut Criterion) {
-    let fo = FileOutline {
-        imports: vec![
-            "Mathlib.Tactic".into(),
-            "Mathlib.Data.Nat.Basic".into(),
-            "Mathlib.Order.Lattice".into(),
-        ],
-        declarations: vec![
-            OutlineEntry {
-                name: "MyNamespace".into(),
-                kind: "Ns".into(),
-                start_line: 5,
-                end_line: 100,
-                type_signature: None,
-                children: vec![
-                    OutlineEntry {
-                        name: "myTheorem".into(),
-                        kind: "Thm".into(),
-                        start_line: 10,
-                        end_line: 20,
-                        type_signature: Some("∀ (n : Nat), n + 0 = n".into()),
-                        children: vec![],
-                    },
-                    OutlineEntry {
-                        name: "myDef".into(),
-                        kind: "Def".into(),
-                        start_line: 25,
-                        end_line: 35,
-                        type_signature: Some("Nat → Nat".into()),
-                        children: vec![],
-                    },
-                ],
-            },
-            OutlineEntry {
-                name: "anotherDef".into(),
-                kind: "Def".into(),
-                start_line: 105,
-                end_line: 110,
-                type_signature: Some("String → Bool".into()),
-                children: vec![],
-            },
-        ],
-        total_declarations: Some(3),
-    };
-    let json = serde_json::to_string(&fo).unwrap();
-
-    c.bench_function("model_file_outline_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&fo)).unwrap())
-    });
-    c.bench_function("model_file_outline_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<FileOutline>(black_box(&json)).unwrap())
-    });
-}
-
-fn bench_code_actions_result_roundtrip(c: &mut Criterion) {
-    let car = CodeActionsResult {
-        actions: vec![
-            CodeAction {
-                title: "Try this: simp only [Nat.add_comm, Nat.add_assoc]".into(),
-                is_preferred: true,
-                edits: vec![CodeActionEdit {
-                    new_text: "simp only [Nat.add_comm, Nat.add_assoc]".into(),
-                    start_line: 5,
-                    start_column: 3,
-                    end_line: 5,
-                    end_column: 8,
-                }],
-            },
-            CodeAction {
-                title: "Try this: omega".into(),
-                is_preferred: false,
-                edits: vec![CodeActionEdit {
-                    new_text: "omega".into(),
-                    start_line: 5,
-                    start_column: 3,
-                    end_line: 5,
-                    end_column: 8,
-                }],
-            },
-        ],
-    };
-    let json = serde_json::to_string(&car).unwrap();
-
-    c.bench_function("model_code_actions_result_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&car)).unwrap())
-    });
-    c.bench_function("model_code_actions_result_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<CodeActionsResult>(black_box(&json)).unwrap())
-    });
-}
-
-fn bench_proof_profile_result_roundtrip(c: &mut Criterion) {
-    let mut categories = HashMap::new();
-    categories.insert("elaboration".into(), 42.5);
-    categories.insert("type_checking".into(), 13.2);
-    categories.insert("tactic".into(), 28.8);
-    let ppr = ProofProfileResult {
-        ms: 84.5,
-        lines: vec![
-            LineProfile {
-                line: 10,
-                ms: 42.5,
-                text: "  exact h".into(),
-            },
-            LineProfile {
-                line: 15,
-                ms: 28.8,
-                text: "  simp [Nat.add_comm]".into(),
-            },
-            LineProfile {
-                line: 20,
-                ms: 13.2,
-                text: "  ring".into(),
-            },
-        ],
-        categories,
-    };
-    let json = serde_json::to_string(&ppr).unwrap();
-
-    c.bench_function("model_proof_profile_result_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&ppr)).unwrap())
-    });
-    c.bench_function("model_proof_profile_result_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<ProofProfileResult>(black_box(&json)).unwrap())
-    });
-}
-
-fn bench_verify_result_roundtrip(c: &mut Criterion) {
-    let vr = VerifyResult {
-        axioms: vec![
-            "propext".into(),
-            "Classical.choice".into(),
-            "Quot.sound".into(),
-        ],
-        warnings: vec![],
-    };
-    let json = serde_json::to_string(&vr).unwrap();
-
-    c.bench_function("model_verify_result_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&vr)).unwrap())
-    });
-    c.bench_function("model_verify_result_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<VerifyResult>(black_box(&json)).unwrap())
-    });
-}
-
-fn bench_build_result_roundtrip(c: &mut Criterion) {
-    let br = BuildResult {
-        success: true,
-        output: "Build completed successfully.\nCompiled 42 modules.".into(),
-        errors: vec![],
-    };
-    let json = serde_json::to_string(&br).unwrap();
-
-    c.bench_function("model_build_result_serialize", |b| {
-        b.iter(|| serde_json::to_string(black_box(&br)).unwrap())
-    });
-    c.bench_function("model_build_result_deserialize", |b| {
-        b.iter(|| serde_json::from_str::<BuildResult>(black_box(&json)).unwrap())
+        });
     });
 }
 
 // ---------------------------------------------------------------------------
-// Rate limiter throughput
+// task_manager: update items
 // ---------------------------------------------------------------------------
 
-fn bench_rate_limiter_under_limit(c: &mut Criterion) {
-    c.bench_function("rate_limiter_check_and_record_under_limit", |b| {
-        b.iter(|| {
-            let mut rl = RateLimiter::new();
-            for _ in 0..3 {
-                rl.check_and_record(black_box("leansearch"), 3, 30).unwrap();
-            }
-        })
-    });
-}
+fn bench_task_manager_update_item(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
 
-fn bench_rate_limiter_at_limit(c: &mut Criterion) {
-    c.bench_function("rate_limiter_check_and_record_at_limit", |b| {
-        b.iter(|| {
-            let mut rl = RateLimiter::new();
-            for _ in 0..10 {
-                rl.check_and_record(black_box("leanfinder"), 10, 30)
-                    .unwrap();
-            }
-            // This call should fail.
-            let _ = rl.check_and_record(black_box("leanfinder"), 10, 30);
-        })
-    });
-}
+    let mut group = c.benchmark_group("task_manager_update_item");
 
-fn bench_rate_limiter_multiple_categories(c: &mut Criterion) {
-    let categories = [
-        "leansearch",
-        "loogle",
-        "leanfinder",
-        "state_search",
-        "hammer",
-    ];
-    c.bench_function("rate_limiter_multiple_categories", |b| {
+    group.bench_function("update_5_items", |b| {
         b.iter(|| {
-            let mut rl = RateLimiter::new();
-            for cat in &categories {
-                for _ in 0..3 {
-                    rl.check_and_record(black_box(cat), 6, 30).unwrap();
+            rt.block_on(async {
+                let mgr: TaskManager<String> = TaskManager::new(Duration::from_secs(60));
+                let (id, _token) = mgr.create_task(5).await;
+
+                for i in 0..5 {
+                    mgr.update_item(
+                        black_box(&id),
+                        black_box(i),
+                        ItemStatus::Completed {
+                            result: format!("result_{i}"),
+                        },
+                    )
+                    .await;
                 }
-            }
-        })
+
+                let snap = mgr.get_task(&id).await.unwrap();
+                assert_eq!(snap.completed_count, 5);
+                snap
+            })
+        });
     });
-}
 
-fn bench_rate_limiter_window_pruning(c: &mut Criterion) {
-    use std::time::{Duration, Instant};
+    group.bench_function("update_20_items", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mgr: TaskManager<String> = TaskManager::new(Duration::from_secs(60));
+                let (id, _token) = mgr.create_task(20).await;
 
-    c.bench_function("rate_limiter_window_pruning", |b| {
-        b.iter_custom(|iters| {
-            let mut total = Duration::ZERO;
-            for _ in 0..iters {
-                let mut rl = RateLimiter::new();
-                // Fill via check_and_record then
-                // age-out by using a very short window.
-                for _ in 0..10 {
-                    rl.check_and_record("bench", 100, 3600).unwrap();
+                for i in 0..20 {
+                    mgr.update_item(
+                        black_box(&id),
+                        black_box(i),
+                        ItemStatus::Completed {
+                            result: format!("result_{i}"),
+                        },
+                    )
+                    .await;
                 }
-                // Now time the pruning call with a 0-second window
-                // (all 10 timestamps will be pruned).
-                let start = Instant::now();
-                let _ = rl.check_and_record(black_box("bench"), 100, 0);
-                total += start.elapsed();
-            }
-            total
-        })
+
+                let snap = mgr.get_task(&id).await.unwrap();
+                assert_eq!(snap.completed_count, 20);
+                snap
+            })
+        });
     });
+
+    group.finish();
 }
 
 // ---------------------------------------------------------------------------
@@ -350,24 +269,12 @@ fn bench_rate_limiter_window_pruning(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 
 criterion_group!(
-    model_benches,
-    bench_goal_state_roundtrip,
-    bench_diagnostics_result_roundtrip,
-    bench_hover_info_roundtrip,
-    bench_completions_result_roundtrip,
-    bench_file_outline_roundtrip,
-    bench_code_actions_result_roundtrip,
-    bench_proof_profile_result_roundtrip,
-    bench_verify_result_roundtrip,
-    bench_build_result_roundtrip,
+    benches,
+    bench_detect_lean_project,
+    bench_get_relative_file_path,
+    bench_check_stale_imports,
+    bench_task_manager_create_and_poll,
+    bench_task_manager_update_item,
 );
 
-criterion_group!(
-    rate_limiter_benches,
-    bench_rate_limiter_under_limit,
-    bench_rate_limiter_at_limit,
-    bench_rate_limiter_multiple_categories,
-    bench_rate_limiter_window_pruning,
-);
-
-criterion_main!(model_benches, rate_limiter_benches);
+criterion_main!(benches);

--- a/crates/lean-mcp-server/Cargo.toml
+++ b/crates/lean-mcp-server/Cargo.toml
@@ -29,9 +29,14 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 assert_cmd = "2"
 async-trait = "0.1"
+criterion = { version = "0.5", features = ["html_reports"] }
 predicates = "3"
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util", "macros"] }
 tokio-test = "0.4"
 wiremock = "0.6"
+
+[[bench]]
+name = "server_bench"
+harness = false

--- a/crates/lean-mcp-server/benches/server_bench.rs
+++ b/crates/lean-mcp-server/benches/server_bench.rs
@@ -1,0 +1,194 @@
+//! Criterion microbenchmarks for lean-mcp-server hot paths.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+use lean_mcp_server::server::AppContext;
+use lean_mcp_server::tools::multi_attempt::{
+    filter_diagnostics_by_line_range, prepare_edit, resolve_column, to_diagnostic_messages,
+};
+use lean_mcp_server::tools::search::SearchConfig;
+
+// ---------------------------------------------------------------------------
+// Helpers: diagnostic JSON builders
+// ---------------------------------------------------------------------------
+
+fn make_diagnostic(start_line: u32, end_line: u32, severity: i32, msg: &str) -> Value {
+    json!({
+        "range": {
+            "start": {"line": start_line, "character": 0},
+            "end": {"line": end_line, "character": 10}
+        },
+        "severity": severity,
+        "message": msg
+    })
+}
+
+fn make_diagnostics(count: usize) -> Vec<Value> {
+    (0..count)
+        .map(|i| make_diagnostic(i as u32, i as u32, (i % 4 + 1) as i32, &format!("msg {i}")))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// prepare_edit
+// ---------------------------------------------------------------------------
+
+fn bench_prepare_edit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("prepare_edit");
+
+    group.bench_function("single_line", |b| {
+        let line_text = "    sorry";
+        b.iter(|| {
+            prepare_edit(
+                black_box(line_text),
+                black_box(4),
+                black_box("exact Nat.zero"),
+                black_box(100),
+                black_box(10),
+            )
+        });
+    });
+
+    group.bench_function("multi_line", |b| {
+        let line_text = "    sorry";
+        let snippet = "apply And.intro\n  exact h1\n  exact h2";
+        b.iter(|| {
+            prepare_edit(
+                black_box(line_text),
+                black_box(4),
+                black_box(snippet),
+                black_box(100),
+                black_box(10),
+            )
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// filter_diagnostics_by_line_range
+// ---------------------------------------------------------------------------
+
+fn bench_filter_diagnostics_by_line_range(c: &mut Criterion) {
+    let mut group = c.benchmark_group("filter_diagnostics_by_line_range");
+
+    group.bench_function("10_diags", |b| {
+        let diags = make_diagnostics(10);
+        b.iter(|| filter_diagnostics_by_line_range(black_box(&diags), black_box(3), black_box(7)));
+    });
+
+    group.bench_function("100_diags", |b| {
+        let diags = make_diagnostics(100);
+        b.iter(|| {
+            filter_diagnostics_by_line_range(black_box(&diags), black_box(30), black_box(70))
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// to_diagnostic_messages
+// ---------------------------------------------------------------------------
+
+fn bench_to_diagnostic_messages(c: &mut Criterion) {
+    let mut group = c.benchmark_group("to_diagnostic_messages");
+
+    group.bench_function("10_diags", |b| {
+        let diags = make_diagnostics(10);
+        b.iter(|| to_diagnostic_messages(black_box(&diags)));
+    });
+
+    group.bench_function("100_diags", |b| {
+        let diags = make_diagnostics(100);
+        b.iter(|| to_diagnostic_messages(black_box(&diags)));
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// resolve_column
+// ---------------------------------------------------------------------------
+
+fn bench_resolve_column(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolve_column");
+
+    group.bench_function("auto_detect", |b| {
+        let line = "    sorry";
+        b.iter(|| resolve_column(black_box(line), black_box(None)));
+    });
+
+    group.bench_function("explicit_column", |b| {
+        let line = "    sorry";
+        b.iter(|| resolve_column(black_box(line), black_box(Some(5))));
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// resolve_project_path
+// ---------------------------------------------------------------------------
+
+fn bench_resolve_project_path(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolve_project_path");
+
+    // Fastest: explicit path always wins
+    group.bench_function("explicit_path", |b| {
+        let ctx = AppContext::with_options(
+            Some(PathBuf::from("/explicit/lean/project")),
+            SearchConfig::default(),
+        );
+        b.iter(|| {
+            let result = ctx.resolve_project_path(black_box(None));
+            assert!(result.is_ok());
+            result
+        });
+    });
+
+    // File detection: walk up from a file in a temp Lean project
+    group.bench_function("file_detection", |b| {
+        b.iter_batched(
+            || {
+                let dir = TempDir::new().unwrap();
+                let sub = dir.path().join("src");
+                fs::create_dir_all(&sub).unwrap();
+                fs::write(dir.path().join("lakefile.lean"), "-- lakefile").unwrap();
+                let file = sub.join("Foo.lean");
+                fs::write(&file, "-- foo").unwrap();
+                let file_str = file.to_string_lossy().to_string();
+                let ctx = AppContext::new();
+                (dir, ctx, file_str)
+            },
+            |(_dir, ctx, file_str)| {
+                let result = ctx.resolve_project_path(Some(&file_str));
+                assert!(result.is_ok());
+                result
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Groups
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    benches,
+    bench_prepare_edit,
+    bench_filter_diagnostics_by_line_range,
+    bench_to_diagnostic_messages,
+    bench_resolve_column,
+    bench_resolve_project_path,
+);
+
+criterion_main!(benches);

--- a/crates/lean-mcp-server/src/lib.rs
+++ b/crates/lean-mcp-server/src/lib.rs
@@ -1,0 +1,6 @@
+//! Library root for lean-mcp-server.
+//!
+//! Exposes internal modules for integration tests and benchmarks.
+
+pub mod server;
+pub mod tools;

--- a/crates/lean-mcp-server/src/main.rs
+++ b/crates/lean-mcp-server/src/main.rs
@@ -1,9 +1,8 @@
 use clap::Parser;
 use lean_mcp_core::config::CliArgs;
+use lean_mcp_server::server;
+use lean_mcp_server::tools;
 use tracing_subscriber::EnvFilter;
-
-mod server;
-mod tools;
 
 #[tokio::main]
 async fn main() {

--- a/crates/lean-mcp-server/src/server.rs
+++ b/crates/lean-mcp-server/src/server.rs
@@ -395,7 +395,7 @@ impl AppContext {
     /// 2. Auto-detect from file_path (walk up looking for project markers)
     /// 3. Auto-detect from CWD (cached)
     /// 4. Error
-    fn resolve_project_path(&self, file_path: Option<&str>) -> Result<PathBuf, String> {
+    pub fn resolve_project_path(&self, file_path: Option<&str>) -> Result<PathBuf, String> {
         // 1. Explicit path
         if let Some(ref pp) = self.explicit_project_path {
             return Ok(pp.clone());

--- a/crates/lean-mcp-server/src/tools/multi_attempt.rs
+++ b/crates/lean-mcp-server/src/tools/multi_attempt.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 
 /// Convert raw LSP diagnostics into [`DiagnosticMessage`] items.
-fn to_diagnostic_messages(diagnostics: &[Value]) -> Vec<DiagnosticMessage> {
+pub fn to_diagnostic_messages(diagnostics: &[Value]) -> Vec<DiagnosticMessage> {
     let mut items = Vec::new();
     for diag in diagnostics {
         let range = diag.get("fullRange").or_else(|| diag.get("range"));
@@ -66,7 +66,7 @@ fn to_diagnostic_messages(diagnostics: &[Value]) -> Vec<DiagnosticMessage> {
 }
 
 /// Filter diagnostics whose range intersects `[start_line, end_line]` (0-indexed).
-fn filter_diagnostics_by_line_range(
+pub fn filter_diagnostics_by_line_range(
     diagnostics: &[Value],
     start_line: u32,
     end_line: u32,
@@ -96,7 +96,7 @@ fn filter_diagnostics_by_line_range(
 /// When `column` is `None`, returns the index of the first non-whitespace
 /// character on the line (or 0 if the line is all whitespace).
 /// When `column` is `Some(c)` (1-indexed), validates the range and returns `c - 1`.
-fn resolve_column(line_text: &str, column: Option<u32>) -> Result<u32, LeanToolError> {
+pub fn resolve_column(line_text: &str, column: Option<u32>) -> Result<u32, LeanToolError> {
     match column {
         None => Ok(line_text.find(|c: char| !c.is_whitespace()).unwrap_or(0) as u32),
         Some(col) => {
@@ -114,7 +114,7 @@ fn resolve_column(line_text: &str, column: Option<u32>) -> Result<u32, LeanToolE
 /// Build the temporary LSP edit and return the goal cursor position.
 ///
 /// Returns `(snippet_str, change_json, goal_line_0, goal_col_0)`.
-fn prepare_edit(
+pub fn prepare_edit(
     line_text: &str,
     target_col: u32,
     snippet: &str,
@@ -367,7 +367,7 @@ async fn lsp_path(
 
 /// Run a single snippet against the warm LSP using edit-and-restore.
 ///
-/// This is the per-snippet body extracted from [`lsp_path`]. It:
+/// This is the per-snippet body extracted from `lsp_path`. It:
 /// 1. Applies the snippet edit at `target_col` on `line`
 /// 2. Gets diagnostics and goals
 /// 3. Restores the original content


### PR DESCRIPTION
## Summary
- Add criterion microbenchmarks for `lean-mcp-core` (`detect_lean_project`, `get_relative_file_path`, `check_stale_imports`, `TaskManager` create/poll/update)
- Add criterion microbenchmarks for `lean-mcp-server` (`prepare_edit`, `filter_diagnostics_by_line_range`, `to_diagnostic_messages`, `resolve_column`, `resolve_project_path`)
- Add `lib.rs` to `lean-mcp-server` to expose modules for benchmark access
- Make helper functions in `multi_attempt.rs` and `resolve_project_path` public for benchmarking

## Test plan
- [x] `cargo test --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` passes
- [x] `cargo bench --bench core_bench -- --test` runs all benchmarks
- [x] `cargo bench --bench server_bench -- --test` runs all benchmarks

Closes #103