### PR TITLE
feat: auto-scaling LSP pool for multi-instance lake serve

### DIFF
--- a/crates/lean-lsp-client/src/lean_client.rs
+++ b/crates/lean-lsp-client/src/lean_client.rs
@@ -177,65 +177,76 @@ impl LspClient for LeanLspClient {
             .await
             .map_err(|e| LspClientError::Transport(TransportError::Io(e)))?;
 
-        let mut files = self.open_files.lock().await;
+        // Prepare notification under lock, then release before sending.
+        let notification = {
+            let mut files = self.open_files.lock().await;
 
-        if let Some(state) = files.get_mut(relative_path) {
-            // File already open — check if disk content has changed
-            if disk_content != state.content {
-                state.version += 1;
-                state.content = disk_content.clone();
-
-                let params = json!({
-                    "textDocument": {
-                        "uri": path_to_uri(&self.project_path, relative_path),
-                        "version": state.version,
+            if let Some(state) = files.get_mut(relative_path) {
+                if disk_content != state.content {
+                    state.version += 1;
+                    state.content = disk_content.clone();
+                    Some((
+                        "textDocument/didChange",
+                        json!({
+                            "textDocument": {
+                                "uri": path_to_uri(&self.project_path, relative_path),
+                                "version": state.version,
+                            },
+                            "contentChanges": [{"text": disk_content}],
+                        }),
+                    ))
+                } else {
+                    None // no change needed
+                }
+            } else {
+                // First open
+                files.insert(
+                    relative_path.to_string(),
+                    FileState {
+                        version: 1,
+                        content: disk_content.clone(),
                     },
-                    "contentChanges": [{"text": disk_content}],
-                });
-                self.multiplexer
-                    .notify("textDocument/didChange", Some(params))
-                    .await
-                    .map_err(mux_err)?;
+                );
+                Some((
+                    "textDocument/didOpen",
+                    json!({
+                        "textDocument": {
+                            "uri": path_to_uri(&self.project_path, relative_path),
+                            "languageId": "lean4",
+                            "version": 1,
+                            "text": disk_content,
+                        }
+                    }),
+                ))
             }
-            return Ok(());
+        }; // lock released
+
+        if let Some((method, params)) = notification {
+            self.multiplexer
+                .notify(method, Some(params))
+                .await
+                .map_err(mux_err)?;
         }
-
-        // First open — send didOpen
-        let params = json!({
-            "textDocument": {
-                "uri": path_to_uri(&self.project_path, relative_path),
-                "languageId": "lean4",
-                "version": 1,
-                "text": disk_content,
-            }
-        });
-        self.multiplexer
-            .notify("textDocument/didOpen", Some(params))
-            .await
-            .map_err(mux_err)?;
-
-        files.insert(
-            relative_path.to_string(),
-            FileState {
-                version: 1,
-                content: disk_content,
-            },
-        );
         Ok(())
     }
 
     async fn open_file_force(&self, relative_path: &str) -> Result<(), LspClientError> {
-        {
+        let close_params = {
             let mut files = self.open_files.lock().await;
             if files.remove(relative_path).is_some() {
-                let params = json!({
+                Some(json!({
                     "textDocument": {"uri": path_to_uri(&self.project_path, relative_path)}
-                });
-                self.multiplexer
-                    .notify("textDocument/didClose", Some(params))
-                    .await
-                    .map_err(mux_err)?;
+                }))
+            } else {
+                None
             }
+        }; // lock released
+
+        if let Some(params) = close_params {
+            self.multiplexer
+                .notify("textDocument/didClose", Some(params))
+                .await
+                .map_err(mux_err)?;
         }
         self.open_file(relative_path).await
     }
@@ -253,19 +264,21 @@ impl LspClient for LeanLspClient {
         relative_path: &str,
         changes: Vec<Value>,
     ) -> Result<(), LspClientError> {
-        let mut files = self.open_files.lock().await;
-        let state = files
-            .get_mut(relative_path)
-            .ok_or_else(|| LspClientError::FileNotOpen(relative_path.to_string()))?;
-        state.version += 1;
+        let params = {
+            let mut files = self.open_files.lock().await;
+            let state = files
+                .get_mut(relative_path)
+                .ok_or_else(|| LspClientError::FileNotOpen(relative_path.to_string()))?;
+            state.version += 1;
+            json!({
+                "textDocument": {
+                    "uri": path_to_uri(&self.project_path, relative_path),
+                    "version": state.version,
+                },
+                "contentChanges": changes,
+            })
+        }; // lock released
 
-        let params = json!({
-            "textDocument": {
-                "uri": path_to_uri(&self.project_path, relative_path),
-                "version": state.version,
-            },
-            "contentChanges": changes,
-        });
         self.multiplexer
             .notify("textDocument/didChange", Some(params))
             .await
@@ -278,20 +291,22 @@ impl LspClient for LeanLspClient {
         relative_path: &str,
         content: &str,
     ) -> Result<(), LspClientError> {
-        let mut files = self.open_files.lock().await;
-        let state = files
-            .get_mut(relative_path)
-            .ok_or_else(|| LspClientError::FileNotOpen(relative_path.to_string()))?;
-        state.version += 1;
-        state.content = content.to_string();
+        let params = {
+            let mut files = self.open_files.lock().await;
+            let state = files
+                .get_mut(relative_path)
+                .ok_or_else(|| LspClientError::FileNotOpen(relative_path.to_string()))?;
+            state.version += 1;
+            state.content = content.to_string();
+            json!({
+                "textDocument": {
+                    "uri": path_to_uri(&self.project_path, relative_path),
+                    "version": state.version,
+                },
+                "contentChanges": [{"text": content}],
+            })
+        }; // lock released
 
-        let params = json!({
-            "textDocument": {
-                "uri": path_to_uri(&self.project_path, relative_path),
-                "version": state.version,
-            },
-            "contentChanges": [{"text": content}],
-        });
         self.multiplexer
             .notify("textDocument/didChange", Some(params))
             .await
@@ -300,17 +315,25 @@ impl LspClient for LeanLspClient {
     }
 
     async fn close_files(&self, paths: &[String]) -> Result<(), LspClientError> {
-        let mut files = self.open_files.lock().await;
-        for path in paths {
-            if files.remove(path).is_some() {
-                let params = json!({
-                    "textDocument": {"uri": path_to_uri(&self.project_path, path)}
-                });
-                self.multiplexer
-                    .notify("textDocument/didClose", Some(params))
-                    .await
-                    .map_err(mux_err)?;
+        // Collect notifications under lock, then send after releasing.
+        let notifications = {
+            let mut files = self.open_files.lock().await;
+            let mut notifs = Vec::new();
+            for path in paths {
+                if files.remove(path).is_some() {
+                    notifs.push(json!({
+                        "textDocument": {"uri": path_to_uri(&self.project_path, path)}
+                    }));
+                }
             }
+            notifs
+        }; // lock released
+
+        for params in notifications {
+            self.multiplexer
+                .notify("textDocument/didClose", Some(params))
+                .await
+                .map_err(mux_err)?;
         }
         Ok(())
     }

--- a/crates/lean-lsp-client/src/lib.rs
+++ b/crates/lean-lsp-client/src/lib.rs
@@ -8,5 +8,6 @@ pub mod error;
 pub mod jsonrpc;
 pub mod lean_client;
 pub mod multiplexer;
+pub mod pool;
 pub mod transport;
 pub mod types;

--- a/crates/lean-lsp-client/src/pool.rs
+++ b/crates/lean-lsp-client/src/pool.rs
@@ -1,0 +1,844 @@
+//! Auto-scaling pool of LSP client instances for concurrent request dispatch.
+//!
+//! [`LspClientPool`] wraps multiple [`LspClient`] instances backed by separate
+//! `lake serve` processes. It implements the [`LspClient`] trait itself, making
+//! it transparent to callers — tool handlers don't know they're talking to a
+//! pool.
+//!
+//! # Routing
+//!
+//! Requests are routed using **file-affinity with least-loaded fallback**:
+//! 1. If a file has been opened on a specific instance, subsequent requests
+//!    for that file prefer that instance (avoids re-elaboration cost).
+//! 2. If the preferred instance is saturated, the least-loaded instance is
+//!    chosen instead.
+//!
+//! # Auto-scaling
+//!
+//! The pool starts with a single instance and grows on demand when all
+//! existing instances are busy. Growth is capped at `max_instances`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::{RwLock, Semaphore};
+use tracing::{debug, info, warn};
+
+use crate::client::{LspClient, LspClientError};
+
+/// In-flight request threshold above which an instance is considered saturated
+/// for affinity routing purposes.
+const SATURATION_THRESHOLD: usize = 2;
+
+/// Type alias for the async spawner function that creates new LSP client instances.
+pub type ClientSpawner = Box<
+    dyn Fn()
+            -> Pin<Box<dyn std::future::Future<Output = Result<Arc<dyn LspClient>, String>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// A single LSP client instance within the pool, with in-flight tracking.
+struct PooledInstance {
+    client: Arc<dyn LspClient>,
+    in_flight: AtomicUsize,
+}
+
+/// RAII guard that decrements the in-flight counter when dropped.
+struct InstanceGuard {
+    instance: Arc<PooledInstance>,
+}
+
+impl Drop for InstanceGuard {
+    fn drop(&mut self) {
+        self.instance.in_flight.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl InstanceGuard {
+    fn client(&self) -> &dyn LspClient {
+        self.instance.client.as_ref()
+    }
+}
+
+/// Auto-scaling pool of LSP client instances.
+///
+/// Implements [`LspClient`] by routing each request to the best available
+/// instance based on file affinity and load.
+pub struct LspClientPool {
+    project_path: PathBuf,
+    instances: Arc<RwLock<Vec<Arc<PooledInstance>>>>,
+    /// Maps relative file paths to the index of the instance that has them open.
+    file_affinity: Arc<RwLock<HashMap<String, usize>>>,
+    max_instances: usize,
+    /// Semaphore with 1 permit — gates concurrent instance spawning.
+    spawn_gate: Arc<Semaphore>,
+    /// Factory function for creating new LSP client instances.
+    spawner: Arc<ClientSpawner>,
+}
+
+impl std::fmt::Debug for LspClientPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LspClientPool")
+            .field("project_path", &self.project_path)
+            .field("max_instances", &self.max_instances)
+            .finish()
+    }
+}
+
+impl LspClientPool {
+    /// Create a new pool with a single initial instance.
+    ///
+    /// The `spawner` is called to create additional instances on demand.
+    /// The `initial_client` is the first (already-connected) instance.
+    pub fn new(
+        project_path: PathBuf,
+        initial_client: Arc<dyn LspClient>,
+        max_instances: usize,
+        spawner: ClientSpawner,
+    ) -> Self {
+        let instance = Arc::new(PooledInstance {
+            client: initial_client,
+            in_flight: AtomicUsize::new(0),
+        });
+        Self {
+            project_path,
+            instances: Arc::new(RwLock::new(vec![instance])),
+            file_affinity: Arc::new(RwLock::new(HashMap::new())),
+            max_instances: max_instances.max(1),
+            spawn_gate: Arc::new(Semaphore::new(1)),
+            spawner: Arc::new(spawner),
+        }
+    }
+
+    /// Acquire an instance for a request, returning a guard that tracks in-flight count.
+    ///
+    /// Routing logic:
+    /// 1. File affinity: prefer the instance that has the file open
+    /// 2. Least-loaded fallback: pick the instance with fewest in-flight requests
+    /// 3. Scale-up: if all instances are busy, spawn a new one (async, non-blocking)
+    async fn acquire(&self, relative_path: Option<&str>) -> Result<InstanceGuard, LspClientError> {
+        let instances = self.instances.read().await;
+
+        // 1. File affinity check
+        if let Some(path) = relative_path {
+            let affinity = self.file_affinity.read().await;
+            if let Some(&idx) = affinity.get(path) {
+                if idx < instances.len() {
+                    let inst = &instances[idx];
+                    let load = inst.in_flight.load(Ordering::Relaxed);
+                    if load < SATURATION_THRESHOLD {
+                        inst.in_flight.fetch_add(1, Ordering::Relaxed);
+                        return Ok(InstanceGuard {
+                            instance: inst.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // 2. Least-loaded
+        let (idx, min_load) = instances
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, inst)| inst.in_flight.load(Ordering::Relaxed))
+            .map(|(i, inst)| (i, inst.in_flight.load(Ordering::Relaxed)))
+            .expect("pool must have at least one instance");
+
+        instances[idx].in_flight.fetch_add(1, Ordering::Relaxed);
+        let guard = InstanceGuard {
+            instance: instances[idx].clone(),
+        };
+
+        let current_len = instances.len();
+        drop(instances); // release read lock before potentially spawning
+
+        // 3. Scale up in background if all instances are busy
+        if min_load >= 1 && current_len < self.max_instances {
+            let instances = Arc::clone(&self.instances);
+            let spawn_gate = Arc::clone(&self.spawn_gate);
+            let spawner = Arc::clone(&self.spawner);
+            let max = self.max_instances;
+
+            tokio::spawn(async move {
+                Self::maybe_spawn_instance(instances, spawn_gate, spawner, max).await;
+            });
+        }
+
+        Ok(guard)
+    }
+
+    /// Attempt to spawn a new instance if under the cap.
+    ///
+    /// Runs in a background task. Uses a semaphore so only one spawn happens
+    /// at a time — if another spawn is in progress, returns immediately.
+    async fn maybe_spawn_instance(
+        instances: Arc<RwLock<Vec<Arc<PooledInstance>>>>,
+        spawn_gate: Arc<Semaphore>,
+        spawner: Arc<ClientSpawner>,
+        max_instances: usize,
+    ) {
+        let permit = match spawn_gate.try_acquire() {
+            Ok(p) => p,
+            Err(_) => return, // another spawn in progress
+        };
+
+        // Double-check under permit
+        let current_len = instances.read().await.len();
+        if current_len >= max_instances {
+            drop(permit);
+            return;
+        }
+
+        info!(
+            "Pool scaling up: spawning instance {} (max {})",
+            current_len, max_instances
+        );
+
+        match spawner().await {
+            Ok(client) => {
+                let instance = Arc::new(PooledInstance {
+                    client,
+                    in_flight: AtomicUsize::new(0),
+                });
+                let mut inst_vec = instances.write().await;
+                inst_vec.push(instance);
+                info!("Pool now has {} instances", inst_vec.len());
+            }
+            Err(e) => {
+                warn!("Failed to spawn new pool instance: {e}");
+            }
+        }
+
+        drop(permit);
+    }
+
+    /// Update file affinity when a file is opened on an instance.
+    async fn set_affinity(&self, relative_path: &str, instance: &Arc<PooledInstance>) {
+        let instances = self.instances.read().await;
+        if let Some(idx) = instances
+            .iter()
+            .position(|inst| Arc::ptr_eq(&inst.client, &instance.client))
+        {
+            let mut affinity = self.file_affinity.write().await;
+            affinity.insert(relative_path.to_string(), idx);
+            debug!(file = relative_path, instance = idx, "affinity set");
+        }
+    }
+
+    /// Clear affinity for files associated with a given instance index.
+    ///
+    /// Used when an instance is removed from the pool (e.g., on failure).
+    #[allow(dead_code)]
+    async fn clear_affinity_for(&self, idx: usize) {
+        let mut affinity = self.file_affinity.write().await;
+        affinity.retain(|_, v| *v != idx);
+    }
+
+    // -- Pool stats for observability --
+
+    /// Number of instances currently in the pool.
+    pub async fn instance_count(&self) -> usize {
+        self.instances.read().await.len()
+    }
+
+    /// Maximum number of instances allowed.
+    pub fn max_instances(&self) -> usize {
+        self.max_instances
+    }
+
+    /// Per-instance in-flight counts.
+    pub async fn in_flight_counts(&self) -> Vec<usize> {
+        self.instances
+            .read()
+            .await
+            .iter()
+            .map(|inst| inst.in_flight.load(Ordering::Relaxed))
+            .collect()
+    }
+
+    /// Number of file-affinity entries tracked.
+    pub async fn affinity_entry_count(&self) -> usize {
+        self.file_affinity.read().await.len()
+    }
+}
+
+#[async_trait]
+impl LspClient for LspClientPool {
+    fn project_path(&self) -> &Path {
+        &self.project_path
+    }
+
+    async fn open_file(&self, relative_path: &str) -> Result<(), LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        let result = guard.client().open_file(relative_path).await;
+        if result.is_ok() {
+            self.set_affinity(relative_path, &guard.instance).await;
+        }
+        result
+    }
+
+    async fn open_file_force(&self, relative_path: &str) -> Result<(), LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        let result = guard.client().open_file_force(relative_path).await;
+        if result.is_ok() {
+            self.set_affinity(relative_path, &guard.instance).await;
+        }
+        result
+    }
+
+    async fn get_file_content(&self, relative_path: &str) -> Result<String, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard.client().get_file_content(relative_path).await
+    }
+
+    async fn update_file(
+        &self,
+        relative_path: &str,
+        changes: Vec<Value>,
+    ) -> Result<(), LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard.client().update_file(relative_path, changes).await
+    }
+
+    async fn update_file_content(
+        &self,
+        relative_path: &str,
+        content: &str,
+    ) -> Result<(), LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .update_file_content(relative_path, content)
+            .await
+    }
+
+    async fn close_files(&self, paths: &[String]) -> Result<(), LspClientError> {
+        // Group paths by affinity to minimize cross-instance calls.
+        // For simplicity, route to the first path's affinity or least-loaded.
+        let first_path = paths.first().map(|s| s.as_str());
+        let guard = self.acquire(first_path).await?;
+        let result = guard.client().close_files(paths).await;
+        if result.is_ok() {
+            let mut affinity = self.file_affinity.write().await;
+            for path in paths {
+                affinity.remove(path);
+            }
+        }
+        result
+    }
+
+    async fn get_diagnostics(
+        &self,
+        relative_path: &str,
+        start_line: Option<u32>,
+        end_line: Option<u32>,
+        inactivity_timeout: Option<f64>,
+    ) -> Result<Value, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_diagnostics(relative_path, start_line, end_line, inactivity_timeout)
+            .await
+    }
+
+    async fn get_interactive_diagnostics(
+        &self,
+        relative_path: &str,
+        start_line: Option<u32>,
+        end_line: Option<u32>,
+    ) -> Result<Vec<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_interactive_diagnostics(relative_path, start_line, end_line)
+            .await
+    }
+
+    async fn get_goal(
+        &self,
+        relative_path: &str,
+        line: u32,
+        column: u32,
+    ) -> Result<Option<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard.client().get_goal(relative_path, line, column).await
+    }
+
+    async fn get_term_goal(
+        &self,
+        relative_path: &str,
+        line: u32,
+        column: u32,
+    ) -> Result<Option<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_term_goal(relative_path, line, column)
+            .await
+    }
+
+    async fn get_hover(
+        &self,
+        relative_path: &str,
+        line: u32,
+        column: u32,
+    ) -> Result<Option<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard.client().get_hover(relative_path, line, column).await
+    }
+
+    async fn get_completions(
+        &self,
+        relative_path: &str,
+        line: u32,
+        column: u32,
+    ) -> Result<Vec<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_completions(relative_path, line, column)
+            .await
+    }
+
+    async fn get_declarations(
+        &self,
+        relative_path: &str,
+        line: u32,
+        column: u32,
+    ) -> Result<Vec<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_declarations(relative_path, line, column)
+            .await
+    }
+
+    async fn get_references(
+        &self,
+        relative_path: &str,
+        line: u32,
+        column: u32,
+        include_declaration: bool,
+    ) -> Result<Vec<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_references(relative_path, line, column, include_declaration)
+            .await
+    }
+
+    async fn get_document_symbols(
+        &self,
+        relative_path: &str,
+    ) -> Result<Vec<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard.client().get_document_symbols(relative_path).await
+    }
+
+    async fn get_code_actions(
+        &self,
+        relative_path: &str,
+        start_line: u32,
+        start_col: u32,
+        end_line: u32,
+        end_col: u32,
+    ) -> Result<Vec<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_code_actions(relative_path, start_line, start_col, end_line, end_col)
+            .await
+    }
+
+    async fn get_code_action_resolve(&self, action: Value) -> Result<Value, LspClientError> {
+        // Code action resolve has no file path context — use least-loaded.
+        let guard = self.acquire(None).await?;
+        guard.client().get_code_action_resolve(action).await
+    }
+
+    async fn get_widgets(
+        &self,
+        relative_path: &str,
+        line: u32,
+        column: u32,
+    ) -> Result<Vec<Value>, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_widgets(relative_path, line, column)
+            .await
+    }
+
+    async fn get_widget_source(
+        &self,
+        relative_path: &str,
+        line: u32,
+        column: u32,
+        javascript_hash: &str,
+    ) -> Result<Value, LspClientError> {
+        let guard = self.acquire(Some(relative_path)).await?;
+        guard
+            .client()
+            .get_widget_source(relative_path, line, column, javascript_hash)
+            .await
+    }
+
+    async fn shutdown(&self) -> Result<(), LspClientError> {
+        let instances = self.instances.read().await;
+        info!("Shutting down pool with {} instances", instances.len());
+        for (i, inst) in instances.iter().enumerate() {
+            if let Err(e) = inst.client.shutdown().await {
+                warn!("Failed to shut down pool instance {i}: {e}");
+            }
+        }
+        // Clear affinity
+        self.file_affinity.write().await.clear();
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::MockLspClient;
+
+    /// Helper: create a mock client with a project path and open_file expectation.
+    fn mock_client(project: &str) -> Arc<dyn LspClient> {
+        let mut mock = MockLspClient::new();
+        let p = PathBuf::from(project);
+        mock.expect_project_path().return_const(p);
+        Arc::new(mock) as Arc<dyn LspClient>
+    }
+
+    #[tokio::test]
+    async fn pool_starts_with_one_instance() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawner: ClientSpawner = Box::new(|| Box::pin(async { Ok(mock_client("/test")) }));
+        let pool = LspClientPool::new(project, client, 4, spawner);
+
+        assert_eq!(pool.instance_count().await, 1);
+        assert_eq!(pool.max_instances(), 4);
+    }
+
+    #[tokio::test]
+    async fn acquire_returns_guard_and_tracks_in_flight() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawner: ClientSpawner = Box::new(|| Box::pin(async { Ok(mock_client("/test")) }));
+        let pool = LspClientPool::new(project, client, 1, spawner);
+
+        let guard = pool.acquire(None).await.unwrap();
+        assert_eq!(pool.in_flight_counts().await, vec![1]);
+
+        drop(guard);
+        assert_eq!(pool.in_flight_counts().await, vec![0]);
+    }
+
+    #[tokio::test]
+    async fn affinity_routes_to_preferred_instance() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawner: ClientSpawner = Box::new(|| Box::pin(async { Ok(mock_client("/test")) }));
+        let pool = LspClientPool::new(project, client, 4, spawner);
+
+        // Manually add a second instance
+        {
+            let mut instances = pool.instances.write().await;
+            instances.push(Arc::new(PooledInstance {
+                client: mock_client("/test"),
+                in_flight: AtomicUsize::new(0),
+            }));
+        }
+
+        // Set affinity for "Foo.lean" → instance 1
+        {
+            let mut affinity = pool.file_affinity.write().await;
+            affinity.insert("Foo.lean".to_string(), 1);
+        }
+
+        // Acquire for "Foo.lean" — should go to instance 1
+        let guard = pool.acquire(Some("Foo.lean")).await.unwrap();
+        let counts = pool.in_flight_counts().await;
+        assert_eq!(counts[0], 0, "instance 0 should be idle");
+        assert_eq!(counts[1], 1, "instance 1 should have the request");
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn saturated_affinity_falls_back_to_least_loaded() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawner: ClientSpawner = Box::new(|| Box::pin(async { Ok(mock_client("/test")) }));
+        let pool = LspClientPool::new(project, client, 4, spawner);
+
+        // Add second instance
+        {
+            let mut instances = pool.instances.write().await;
+            instances.push(Arc::new(PooledInstance {
+                client: mock_client("/test"),
+                in_flight: AtomicUsize::new(0),
+            }));
+        }
+
+        // Set affinity for "Foo.lean" → instance 0
+        {
+            let mut affinity = pool.file_affinity.write().await;
+            affinity.insert("Foo.lean".to_string(), 0);
+        }
+
+        // Saturate instance 0 beyond threshold
+        {
+            let instances = pool.instances.read().await;
+            for _ in 0..SATURATION_THRESHOLD {
+                instances[0].in_flight.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        // Acquire for "Foo.lean" — should fall back to instance 1 (least loaded)
+        let guard = pool.acquire(Some("Foo.lean")).await.unwrap();
+        let counts = pool.in_flight_counts().await;
+        assert_eq!(
+            counts[1], 1,
+            "should fall back to instance 1 when 0 is saturated"
+        );
+        drop(guard);
+
+        // Clean up
+        {
+            let instances = pool.instances.read().await;
+            instances[0].in_flight.store(0, Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test]
+    async fn auto_scales_when_all_busy() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawn_count = Arc::new(AtomicUsize::new(0));
+        let sc = spawn_count.clone();
+        let spawner: ClientSpawner = Box::new(move || {
+            sc.fetch_add(1, Ordering::Relaxed);
+            Box::pin(async { Ok(mock_client("/test")) })
+        });
+        let pool = LspClientPool::new(project, client, 3, spawner);
+
+        assert_eq!(pool.instance_count().await, 1);
+
+        // Acquire one request — instance 0 is now busy
+        let _guard1 = pool.acquire(None).await.unwrap();
+
+        // Acquire another — should trigger scale-up since all instances busy
+        let _guard2 = pool.acquire(None).await.unwrap();
+
+        // Give the spawn a moment to complete
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        assert_eq!(
+            spawn_count.load(Ordering::Relaxed),
+            1,
+            "should have spawned once"
+        );
+        assert_eq!(pool.instance_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn does_not_exceed_max_instances() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawner: ClientSpawner = Box::new(|| Box::pin(async { Ok(mock_client("/test")) }));
+        let pool = LspClientPool::new(project, client, 2, spawner);
+
+        // Manually add instance to reach max
+        {
+            let mut instances = pool.instances.write().await;
+            instances.push(Arc::new(PooledInstance {
+                client: mock_client("/test"),
+                in_flight: AtomicUsize::new(0),
+            }));
+        }
+        assert_eq!(pool.instance_count().await, 2);
+
+        // Make all busy and try to acquire
+        {
+            let instances = pool.instances.read().await;
+            for inst in instances.iter() {
+                inst.in_flight.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let _guard = pool.acquire(None).await.unwrap();
+
+        // Should NOT have grown past max
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        assert_eq!(pool.instance_count().await, 2, "should not exceed max");
+    }
+
+    #[tokio::test]
+    async fn close_files_clears_affinity() {
+        let project = PathBuf::from("/test");
+        let mut client = MockLspClient::new();
+        client
+            .expect_project_path()
+            .return_const(PathBuf::from("/test"));
+        client.expect_close_files().returning(|_| Ok(()));
+        let client: Arc<dyn LspClient> = Arc::new(client);
+        let spawner: ClientSpawner = Box::new(|| Box::pin(async { Ok(mock_client("/test")) }));
+        let pool = LspClientPool::new(project, client, 4, spawner);
+
+        // Set affinity
+        {
+            let mut affinity = pool.file_affinity.write().await;
+            affinity.insert("A.lean".to_string(), 0);
+            affinity.insert("B.lean".to_string(), 0);
+        }
+
+        pool.close_files(&["A.lean".to_string()]).await.unwrap();
+
+        let affinity = pool.file_affinity.read().await;
+        assert!(
+            !affinity.contains_key("A.lean"),
+            "A.lean affinity should be cleared"
+        );
+        assert!(
+            affinity.contains_key("B.lean"),
+            "B.lean affinity should remain"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_shuts_down_all_instances() {
+        let project = PathBuf::from("/test");
+        let shutdown_count = Arc::new(AtomicUsize::new(0));
+
+        let sc = shutdown_count.clone();
+        let mut client = MockLspClient::new();
+        client
+            .expect_project_path()
+            .return_const(PathBuf::from("/test"));
+        let sc2 = sc.clone();
+        client.expect_shutdown().returning(move || {
+            sc2.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        });
+        let client: Arc<dyn LspClient> = Arc::new(client);
+
+        let sc3 = sc.clone();
+        let spawner: ClientSpawner = Box::new(move || {
+            let sc4 = sc3.clone();
+            Box::pin(async move {
+                let mut mock = MockLspClient::new();
+                mock.expect_project_path()
+                    .return_const(PathBuf::from("/test"));
+                let sc5 = sc4.clone();
+                mock.expect_shutdown().returning(move || {
+                    sc5.fetch_add(1, Ordering::Relaxed);
+                    Ok(())
+                });
+                Ok(Arc::new(mock) as Arc<dyn LspClient>)
+            })
+        });
+
+        let pool = LspClientPool::new(project, client, 4, spawner);
+
+        // Add a second instance via spawn
+        LspClientPool::maybe_spawn_instance(
+            Arc::clone(&pool.instances),
+            Arc::clone(&pool.spawn_gate),
+            Arc::clone(&pool.spawner),
+            pool.max_instances,
+        )
+        .await;
+        assert_eq!(pool.instance_count().await, 2);
+
+        pool.shutdown().await.unwrap();
+        assert_eq!(shutdown_count.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn affinity_entry_count_tracks_correctly() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawner: ClientSpawner = Box::new(|| Box::pin(async { Ok(mock_client("/test")) }));
+        let pool = LspClientPool::new(project, client, 4, spawner);
+
+        assert_eq!(pool.affinity_entry_count().await, 0);
+
+        {
+            let mut affinity = pool.file_affinity.write().await;
+            affinity.insert("A.lean".to_string(), 0);
+            affinity.insert("B.lean".to_string(), 0);
+        }
+
+        assert_eq!(pool.affinity_entry_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn spawn_failure_does_not_crash_pool() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawner: ClientSpawner =
+            Box::new(|| Box::pin(async { Err("lake serve failed to start".to_string()) }));
+        let pool = LspClientPool::new(project, client, 4, spawner);
+
+        // Make instance busy to trigger scale-up attempt
+        {
+            let instances = pool.instances.read().await;
+            instances[0].in_flight.fetch_add(1, Ordering::Relaxed);
+        }
+
+        // This triggers a scale-up that will fail — should not panic
+        let _guard = pool.acquire(None).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Pool should still have just 1 instance
+        assert_eq!(pool.instance_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn least_loaded_distributes_evenly() {
+        let project = PathBuf::from("/test");
+        let client = mock_client("/test");
+        let spawner: ClientSpawner = Box::new(|| Box::pin(async { Ok(mock_client("/test")) }));
+        let pool = LspClientPool::new(project, client, 4, spawner);
+
+        // Add two more instances (3 total)
+        {
+            let mut instances = pool.instances.write().await;
+            for _ in 0..2 {
+                instances.push(Arc::new(PooledInstance {
+                    client: mock_client("/test"),
+                    in_flight: AtomicUsize::new(0),
+                }));
+            }
+        }
+
+        // Acquire 3 requests without file affinity — should spread across instances
+        let g1 = pool.acquire(None).await.unwrap();
+        let g2 = pool.acquire(None).await.unwrap();
+        let g3 = pool.acquire(None).await.unwrap();
+
+        let counts = pool.in_flight_counts().await;
+        assert_eq!(counts.iter().sum::<usize>(), 3);
+        // Each should have exactly 1 (least-loaded picks idle ones)
+        assert!(
+            counts.iter().all(|&c| c == 1),
+            "expected even distribution, got {:?}",
+            counts
+        );
+
+        drop(g1);
+        drop(g2);
+        drop(g3);
+    }
+}

--- a/crates/lean-mcp-server/src/server.rs
+++ b/crates/lean-mcp-server/src/server.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use lean_lsp_client::client::LspClient;
 use lean_lsp_client::lean_client::LeanLspClient;
+use lean_lsp_client::pool::LspClientPool;
 use lean_mcp_core::instructions::INSTRUCTIONS;
 use lean_mcp_core::models::AttemptResult;
 use lean_mcp_core::task_manager::TaskManager;
@@ -340,8 +341,8 @@ pub struct TaskResultParams {
 pub struct AppContext {
     /// Explicit project path from CLI/env (takes precedence over detection).
     explicit_project_path: Option<PathBuf>,
-    /// Per-project LSP clients, keyed by canonicalized project root.
-    clients: Arc<tokio::sync::RwLock<HashMap<PathBuf, Arc<dyn LspClient>>>>,
+    /// Per-project LSP client pools, keyed by canonicalized project root.
+    clients: Arc<tokio::sync::RwLock<HashMap<PathBuf, Arc<LspClientPool>>>>,
     /// Cached CWD-based project detection result.
     cwd_project: Arc<OnceLock<Option<PathBuf>>>,
     /// Search endpoint configuration (URLs for leansearch, loogle, etc.).
@@ -429,23 +430,23 @@ impl AppContext {
         )
     }
 
-    /// Get or create an LSP client for a specific project.
-    async fn ensure_client_for(&self, project_path: &Path) -> Result<Arc<dyn LspClient>, String> {
+    /// Get or create an LSP client pool for a specific project.
+    async fn ensure_client_for(&self, project_path: &Path) -> Result<Arc<LspClientPool>, String> {
         // Fast path: read lock
         {
             let clients = self.clients.read().await;
-            if let Some(client) = clients.get(project_path) {
-                return Ok(client.clone());
+            if let Some(pool) = clients.get(project_path) {
+                return Ok(pool.clone());
             }
         }
         // Slow path: write lock with double-check
         let mut clients = self.clients.write().await;
-        if let Some(client) = clients.get(project_path) {
-            return Ok(client.clone());
+        if let Some(pool) = clients.get(project_path) {
+            return Ok(pool.clone());
         }
-        let client = spawn_lsp_client(project_path.to_path_buf()).await?;
-        clients.insert(project_path.to_path_buf(), client.clone());
-        Ok(client)
+        let pool = spawn_lsp_pool(project_path.to_path_buf()).await?;
+        clients.insert(project_path.to_path_buf(), pool.clone());
+        Ok(pool)
     }
 
     /// Evict and shut down the LSP client for a project.
@@ -463,13 +464,13 @@ impl AppContext {
     }
 
     /// Convenience: resolve project from file_path, then get client.
-    async fn client_for_file(&self, file_path: &str) -> Result<Arc<dyn LspClient>, String> {
+    async fn client_for_file(&self, file_path: &str) -> Result<Arc<LspClientPool>, String> {
         let project_path = self.resolve_project_path(Some(file_path))?;
         self.ensure_client_for(&project_path).await
     }
 
     /// Convenience: resolve default project, then get client (for tools without file_path).
-    async fn client_default(&self) -> Result<Arc<dyn LspClient>, String> {
+    async fn client_default(&self) -> Result<Arc<LspClientPool>, String> {
         let project_path = self.resolve_project_path(None)?;
         self.ensure_client_for(&project_path).await
     }
@@ -515,6 +516,91 @@ async fn spawn_lsp_client(project_path: PathBuf) -> Result<Arc<dyn LspClient>, S
 
     tracing::info!("LSP client connected");
     Ok(Arc::new(client) as Arc<dyn LspClient>)
+}
+
+/// Spawn an auto-scaling pool of `lake serve` instances for a project.
+///
+/// Starts with a single instance and grows on demand up to [`compute_max_instances`].
+async fn spawn_lsp_pool(project_path: PathBuf) -> Result<Arc<LspClientPool>, String> {
+    let max = compute_max_instances();
+    tracing::info!(
+        "Creating LSP pool for {} (max {max} instances)",
+        project_path.display()
+    );
+
+    let initial = spawn_lsp_client(project_path.clone()).await?;
+
+    let pp = project_path.clone();
+    let spawner: lean_lsp_client::pool::ClientSpawner = Box::new(move || {
+        let pp = pp.clone();
+        Box::pin(async move { spawn_lsp_client(pp).await })
+    });
+
+    let pool = LspClientPool::new(project_path, initial, max, spawner);
+    Ok(Arc::new(pool))
+}
+
+/// Compute the maximum number of LSP instances based on system resources.
+///
+/// Uses CPU count and available memory. Can be overridden via
+/// `LEAN_MCP_MAX_INSTANCES` environment variable.
+fn compute_max_instances() -> usize {
+    // Check env override first
+    if let Ok(val) = std::env::var("LEAN_MCP_MAX_INSTANCES") {
+        if let Ok(n) = val.parse::<usize>() {
+            if n >= 1 {
+                tracing::info!("LEAN_MCP_MAX_INSTANCES override: {n}");
+                return n;
+            }
+        }
+    }
+
+    // CPU-based cap: half of available parallelism
+    let cpu_cap = std::thread::available_parallelism()
+        .map(|p| p.get() / 2)
+        .unwrap_or(2)
+        .max(1);
+
+    // Memory-based cap: ~2 GB per lake serve instance
+    let mem_cap = available_memory_gb()
+        .map(|gb| (gb / 2.0) as usize)
+        .unwrap_or(4)
+        .max(1);
+
+    let cap = cpu_cap.min(mem_cap).clamp(1, 8);
+    tracing::info!("Auto-computed max LSP instances: {cap} (cpu_cap={cpu_cap}, mem_cap={mem_cap})");
+    cap
+}
+
+/// Best-effort detection of available system memory in GB.
+#[cfg(target_os = "macos")]
+fn available_memory_gb() -> Option<f64> {
+    let output = std::process::Command::new("sysctl")
+        .arg("-n")
+        .arg("hw.memsize")
+        .output()
+        .ok()?;
+    let s = String::from_utf8_lossy(&output.stdout);
+    let bytes: u64 = s.trim().parse().ok()?;
+    Some(bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+}
+
+#[cfg(target_os = "linux")]
+fn available_memory_gb() -> Option<f64> {
+    let content = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb_str = rest.trim().trim_end_matches("kB").trim();
+            let kb: u64 = kb_str.parse().ok()?;
+            return Some(kb as f64 / (1024.0 * 1024.0));
+        }
+    }
+    None
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn available_memory_gb() -> Option<f64> {
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -612,7 +698,7 @@ impl AppContext {
         };
         tools::project_health::handle_project_health(
             &project_path,
-            client.as_ref().map(|c| c.as_ref()),
+            client.as_ref().map(|c| c.as_ref() as &dyn LspClient),
             include_goals,
         )
         .await
@@ -732,7 +818,7 @@ impl AppContext {
         };
         let result = tools::batch::handle_batch(
             params.calls,
-            client.as_ref().map(|c| c.as_ref()),
+            client.as_ref().map(|c| c.as_ref() as &dyn LspClient),
             project_path.as_deref(),
             &self.search_config,
         )
@@ -1349,10 +1435,14 @@ impl AppContext {
         let clients = self.clients.read().await;
         let mut sessions = Vec::new();
 
-        for (path, _client) in clients.iter() {
+        for (path, pool) in clients.iter() {
             sessions.push(serde_json::json!({
                 "project_path": path.to_string_lossy(),
                 "status": "active",
+                "pool_size": pool.instance_count().await,
+                "max_pool_size": pool.max_instances(),
+                "in_flight": pool.in_flight_counts().await,
+                "affinity_entries": pool.affinity_entry_count().await,
             }));
         }
         drop(clients);


### PR DESCRIPTION
## Summary

- Auto-scaling pool of `lake serve` instances per project with file-affinity routing
- Starts with 1 instance, grows on demand when concurrent requests saturate all instances
- Cap auto-computed from system resources (`min(cpus/2, memory_gb/2, 8)`), override via `LEAN_MCP_MAX_INSTANCES`
- Background spawning via `tokio::spawn` — never blocks current requests
- Fix `open_files` mutex held across `.await` in `LeanLspClient` (secondary serialization bottleneck)
- Pool implements `LspClient` trait — zero changes to any tool handler files

Closes #122

## Test plan

- [x] 11 new pool unit tests: routing, affinity, scaling, shutdown, failure handling
- [x] All 800 existing tests pass unchanged (pool is transparent)
- [x] Clippy, rustfmt, rustdoc all clean
- [ ] CI passes (6 required checks)