### PR TITLE
fix: update rustls-webpki for RUSTSEC-2026-0049

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Update `rustls-webpki` from 0.103.9 to 0.103.10 to address RUSTSEC-2026-0049
- CRL distribution point matching vulnerability (transitive dep via rmcp → reqwest → rustls)
- Advisory published 2026-03-20, caused Security Audit CI failure on main

## Test plan

- [ ] CI passes (Security Audit specifically)