### PR TITLE
feat: add performance tracing instrumentation for tool call analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +454,15 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "diff"
@@ -1173,6 +1191,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "wiremock",
@@ -1325,6 +1344,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -1496,6 +1521,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2275,6 +2306,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,6 +2509,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/lean-lsp-client/src/multiplexer.rs
+++ b/crates/lean-lsp-client/src/multiplexer.rs
@@ -142,6 +142,8 @@ impl Multiplexer {
         params: Option<Value>,
         timeout: Duration,
     ) -> Result<Value, MultiplexerError> {
+        let request_start = std::time::Instant::now();
+
         // 1. Allocate next request ID.
         let numeric_id = {
             let mut next = self.next_id.lock().await;
@@ -165,7 +167,7 @@ impl Multiplexer {
         let msg_value = serde_json::to_value(&request)
             .map_err(|e| MultiplexerError::Transport(TransportError::Json(e)))?;
 
-        debug!(%id, method, "Sending request");
+        debug!(%id, method, "lsp_request");
 
         self.outgoing_tx
             .send(msg_value)
@@ -174,12 +176,19 @@ impl Multiplexer {
 
         // 5. Wait on oneshot receiver (with timeout).
         match tokio::time::timeout(timeout, rx).await {
-            Ok(Ok(value)) => Ok(value),
+            Ok(Ok(value)) => {
+                let elapsed_ms = request_start.elapsed().as_millis();
+                debug!(%id, method, elapsed_ms, "lsp_response");
+                Ok(value)
+            }
             Ok(Err(_)) => {
-                // Sender was dropped (e.g., multiplexer shut down).
+                let elapsed_ms = request_start.elapsed().as_millis();
+                warn!(%id, method, elapsed_ms, "lsp_shutdown");
                 Err(MultiplexerError::Shutdown)
             }
             Err(_) => {
+                let elapsed_ms = request_start.elapsed().as_millis();
+                warn!(%id, method, elapsed_ms, "lsp_timeout");
                 // Timeout: remove from pending map.
                 let mut pending = self.pending.lock().await;
                 pending.remove(&id);

--- a/crates/lean-lsp-client/src/pool.rs
+++ b/crates/lean-lsp-client/src/pool.rs
@@ -134,10 +134,24 @@ impl LspClientPool {
                     let load = inst.in_flight.load(Ordering::Relaxed);
                     if load < SATURATION_THRESHOLD {
                         inst.in_flight.fetch_add(1, Ordering::Relaxed);
+                        debug!(
+                            routing = "affinity_hit",
+                            instance = idx,
+                            load,
+                            file = path,
+                            "pool_acquire"
+                        );
                         return Ok(InstanceGuard {
                             instance: inst.clone(),
                         });
                     }
+                    debug!(
+                        routing = "affinity_saturated",
+                        instance = idx,
+                        load,
+                        file = path,
+                        "pool_acquire"
+                    );
                 }
             }
         }
@@ -149,6 +163,14 @@ impl LspClientPool {
             .min_by_key(|(_, inst)| inst.in_flight.load(Ordering::Relaxed))
             .map(|(i, inst)| (i, inst.in_flight.load(Ordering::Relaxed)))
             .expect("pool must have at least one instance");
+
+        debug!(
+            routing = "least_loaded",
+            instance = idx,
+            load = min_load,
+            pool_size = instances.len(),
+            "pool_acquire"
+        );
 
         instances[idx].in_flight.fetch_add(1, Ordering::Relaxed);
         let guard = InstanceGuard {

--- a/crates/lean-mcp-server/Cargo.toml
+++ b/crates/lean-mcp-server/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive", "env"] }
 futures = "0.3"
 tracing = "0.1"
+tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]

--- a/crates/lean-mcp-server/src/main.rs
+++ b/crates/lean-mcp-server/src/main.rs
@@ -2,17 +2,52 @@ use clap::Parser;
 use lean_mcp_core::config::CliArgs;
 use lean_mcp_server::server;
 use lean_mcp_server::tools;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() {
     // Initialize tracing (respects RUST_LOG env var).
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .with_writer(std::io::stderr)
-        .init();
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    // Optional file-based tracing for performance analysis.
+    // Set LEAN_MCP_LOG=/tmp/rust-lean-mcp.log to enable.
+    let _guard = if let Ok(log_path) = std::env::var("LEAN_MCP_LOG") {
+        let parent = std::path::Path::new(&log_path)
+            .parent()
+            .unwrap_or(std::path::Path::new("/tmp"));
+        let filename = std::path::Path::new(&log_path)
+            .file_name()
+            .unwrap_or(std::ffi::OsStr::new("rust-lean-mcp.log"));
+        let file_appender = tracing_appender::rolling::never(parent, filename);
+        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_writer(non_blocking)
+            .with_span_events(FmtSpan::CLOSE)
+            .with_target(true)
+            .with_ansi(false);
+
+        let stderr_layer = tracing_subscriber::fmt::layer()
+            .with_writer(std::io::stderr);
+
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(file_layer)
+            .with(stderr_layer)
+            .init();
+
+        Some(guard)
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_writer(std::io::stderr)
+            .init();
+        None
+    };
 
     // Parse CLI args.
     let args = CliArgs::parse_from(std::env::args());

--- a/crates/lean-mcp-server/src/main.rs
+++ b/crates/lean-mcp-server/src/main.rs
@@ -10,8 +10,7 @@ use tracing_subscriber::EnvFilter;
 #[tokio::main]
 async fn main() {
     // Initialize tracing (respects RUST_LOG env var).
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     // Optional file-based tracing for performance analysis.
     // Set LEAN_MCP_LOG=/tmp/rust-lean-mcp.log to enable.
@@ -31,8 +30,7 @@ async fn main() {
             .with_target(true)
             .with_ansi(false);
 
-        let stderr_layer = tracing_subscriber::fmt::layer()
-            .with_writer(std::io::stderr);
+        let stderr_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
 
         tracing_subscriber::registry()
             .with(env_filter)

--- a/crates/lean-mcp-server/src/server.rs
+++ b/crates/lean-mcp-server/src/server.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use lean_lsp_client::client::LspClient;
 use lean_lsp_client::lean_client::LeanLspClient;
@@ -328,6 +328,33 @@ pub struct TaskResultParams {
 }
 
 // ---------------------------------------------------------------------------
+// Performance tracing
+// ---------------------------------------------------------------------------
+
+/// Drop guard that logs tool call duration on drop.
+struct ToolTimer {
+    tool: &'static str,
+    start: Instant,
+}
+
+impl ToolTimer {
+    fn new(tool: &'static str) -> Self {
+        tracing::info!(tool, "tool_call");
+        Self {
+            tool,
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Drop for ToolTimer {
+    fn drop(&mut self) {
+        let elapsed_ms = self.start.elapsed().as_millis();
+        tracing::info!(tool = self.tool, elapsed_ms, "tool_complete");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // AppContext
 // ---------------------------------------------------------------------------
 
@@ -396,6 +423,7 @@ impl AppContext {
     /// 2. Auto-detect from file_path (walk up looking for project markers)
     /// 3. Auto-detect from CWD (cached)
     /// 4. Error
+    #[tracing::instrument(skip(self), level = "debug")]
     pub fn resolve_project_path(&self, file_path: Option<&str>) -> Result<PathBuf, String> {
         // 1. Explicit path
         if let Some(ref pp) = self.explicit_project_path {
@@ -431,6 +459,7 @@ impl AppContext {
     }
 
     /// Get or create an LSP client pool for a specific project.
+    #[tracing::instrument(skip(self), level = "debug")]
     async fn ensure_client_for(&self, project_path: &Path) -> Result<Arc<LspClientPool>, String> {
         // Fast path: read lock
         {
@@ -464,6 +493,7 @@ impl AppContext {
     }
 
     /// Convenience: resolve project from file_path, then get client.
+    #[tracing::instrument(skip(self), level = "debug")]
     async fn client_for_file(&self, file_path: &str) -> Result<Arc<LspClientPool>, String> {
         let project_path = self.resolve_project_path(Some(file_path))?;
         self.ensure_client_for(&project_path).await
@@ -658,6 +688,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<BuildParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_build");
         let project_path = self.resolve_project_path(None)?;
 
         // Shut down the old LSP client before building so it doesn't hold
@@ -689,6 +720,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<ProjectHealthParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_project_health");
         let project_path = self.resolve_project_path(None)?;
         let include_goals = params.include_goals.unwrap_or(false);
         let client = if include_goals {
@@ -715,6 +747,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<FileOutlineParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_file_outline");
         let client = self.client_for_file(&params.file_path).await?;
         tools::outline::handle_file_outline(
             client.as_ref(),
@@ -736,6 +769,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<DiagnosticParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_diagnostic_messages");
         let client = self.client_for_file(&params.file_path).await?;
         let project_path = self.resolve_project_path(Some(&params.file_path))?;
         tools::diagnostics::handle_diagnostics(
@@ -763,6 +797,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<GoalParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_goal");
         let client = self.client_for_file(&params.file_path).await?;
         let line = resolve_line(
             client.as_ref(),
@@ -787,6 +822,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<ProofDiffParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_proof_diff");
         let client = self.client_for_file(&params.file_path).await?;
         tools::proof_diff::handle_lean_proof_diff(
             client.as_ref(),
@@ -811,6 +847,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<BatchParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_batch");
         let project_path = self.resolve_project_path(None).ok();
         let client = match &project_path {
             Some(pp) => self.ensure_client_for(pp).await.ok(),
@@ -836,6 +873,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<TermGoalParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_term_goal");
         let client = self.client_for_file(&params.file_path).await?;
         let line = resolve_line(
             client.as_ref(),
@@ -860,6 +898,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<HoverParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_hover_info");
         let client = self.client_for_file(&params.file_path).await?;
         let line = resolve_line(
             client.as_ref(),
@@ -884,6 +923,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<CompletionsParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_completions");
         let client = self.client_for_file(&params.file_path).await?;
         let line = resolve_line(
             client.as_ref(),
@@ -914,6 +954,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<DeclarationParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_declaration_file");
         let client = self.client_for_file(&params.file_path).await?;
         tools::declarations::handle_declaration_file(
             client.as_ref(),
@@ -935,6 +976,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<ReferencesParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_references");
         let client = self.client_for_file(&params.file_path).await?;
         let line = resolve_line(
             client.as_ref(),
@@ -964,6 +1006,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<MultiAttemptParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_multi_attempt");
         let client = self.client_for_file(&params.file_path).await?;
         tools::multi_attempt::handle_multi_attempt(
             client.as_ref(),
@@ -990,6 +1033,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<MultiAttemptAsyncParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_multi_attempt_async");
         let client = self.client_for_file(&params.file_path).await?;
 
         // Ensure file is open before reading content (#90)
@@ -1124,6 +1168,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<RunCodeParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_run_code");
         let project_path = self.resolve_project_path(None)?;
         let client = self.ensure_client_for(&project_path).await?;
         tools::run_code::handle_run_code(client.as_ref(), &project_path, &params.code)
@@ -1142,6 +1187,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<VerifyParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_verify");
         let client = self.client_for_file(&params.file_path).await?;
         tools::verify::handle_verify(
             client.as_ref(),
@@ -1164,6 +1210,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<LocalSearchParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_local_search");
         let root = match params.project_root {
             Some(r) => PathBuf::from(r),
             None => self.resolve_project_path(None)?,
@@ -1187,6 +1234,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<LeanSearchParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_leansearch");
         tools::search::handle_leansearch(
             &params.query,
             params.num_results.unwrap_or(5),
@@ -1207,6 +1255,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<LoogleParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_loogle");
         tools::search::handle_loogle_remote(
             &params.query,
             params.num_results.unwrap_or(8),
@@ -1227,6 +1276,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<LeanFinderParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_leanfinder");
         tools::search::handle_leanfinder(
             &params.query,
             params.num_results.unwrap_or(5),
@@ -1247,6 +1297,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<StateSearchParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_state_search");
         let client = self.client_for_file(&params.file_path).await?;
         tools::search::handle_state_search(
             client.as_ref(),
@@ -1271,6 +1322,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<HammerPremiseParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_hammer_premise");
         let client = self.client_for_file(&params.file_path).await?;
         tools::search::handle_hammer_premise(
             client.as_ref(),
@@ -1295,6 +1347,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<CodeActionsParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_code_actions");
         let client = self.client_for_file(&params.file_path).await?;
         tools::code_actions::handle_code_actions(client.as_ref(), &params.file_path, params.line)
             .await
@@ -1312,6 +1365,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<GetWidgetsParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_get_widgets");
         let client = self.client_for_file(&params.file_path).await?;
         tools::widgets::handle_get_widgets(
             client.as_ref(),
@@ -1332,6 +1386,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<WidgetSourceParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_get_widget_source");
         let client = self.client_for_file(&params.file_path).await?;
         tools::widgets::handle_get_widget_source(
             client.as_ref(),
@@ -1353,6 +1408,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<ProfileProofParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_profile_proof");
         let project_path = self.resolve_project_path(Some(&params.file_path))?;
         let file = PathBuf::from(&params.file_path);
         tools::profile::handle_profile_proof(
@@ -1377,6 +1433,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<BatchGoalParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_goals_batch");
         let client = self.client_default().await?;
         tools::batch_goals::handle_lean_goals_batch(client.as_ref(), params.positions)
             .await
@@ -1394,6 +1451,7 @@ impl AppContext {
         &self,
         Parameters(params): Parameters<TaskResultParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_task_result");
         // Handle cancellation
         if params.cancel == Some(true) {
             let cancelled = self.task_manager.cancel_task(&params.task_id).await;
@@ -1432,6 +1490,7 @@ impl AppContext {
         &self,
         Parameters(_params): Parameters<ServerHealthParams>,
     ) -> Result<String, String> {
+        let _t = ToolTimer::new("lean_server_health");
         let clients = self.clients.read().await;
         let mut sessions = Vec::new();
 


### PR DESCRIPTION
## Summary
- Add opt-in file-based tracing via `LEAN_MCP_LOG` env var (zero overhead when unset)
- ToolTimer drop guard on all 29 tool handlers logging tool name + elapsed_ms
- `#[instrument]` on client_for_file, ensure_client_for, resolve_project_path
- Pool acquire() logs routing decisions (affinity_hit/saturated/least_loaded)
- Multiplexer request_with_timeout logs LSP method + roundtrip elapsed_ms

## Test plan
- [x] All 800 tests pass
- [x] Clippy clean
- [x] Verified with real traffic (163K trace lines over 4hr session)