### PR TITLE
feat: add LEAN_NUM_THREADS to pool spawn for CPU control (#130)

### DIFF
--- a/crates/lean-mcp-server/src/server.rs
+++ b/crates/lean-mcp-server/src/server.rs
@@ -517,12 +517,27 @@ impl Default for AppContext {
     }
 }
 
+/// Resolve the per-instance thread count from `LEAN_MCP_THREADS_PER_INSTANCE`.
+///
+/// Falls back to `"4"` when the variable is unset or empty.
+fn threads_per_instance() -> String {
+    std::env::var("LEAN_MCP_THREADS_PER_INSTANCE")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "4".to_string())
+}
+
 /// Spawn `lake serve` and create a connected [`LeanLspClient`].
 async fn spawn_lsp_client(project_path: PathBuf) -> Result<Arc<dyn LspClient>, String> {
-    tracing::info!("Spawning `lake serve` in {}", project_path.display());
+    let num_threads = threads_per_instance();
+    tracing::info!(
+        "Spawning `lake serve` in {} with LEAN_NUM_THREADS={num_threads}",
+        project_path.display()
+    );
 
     let mut child = Command::new("lake")
         .arg("serve")
+        .env("LEAN_NUM_THREADS", &num_threads)
         .current_dir(&project_path)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -2011,5 +2026,31 @@ mod tests {
         assert!(!version.is_empty(), "server_version should be non-empty");
         // Should match the compile-time version
         assert_eq!(version, server_version());
+    }
+
+    // ---- threads_per_instance tests ----
+
+    #[test]
+    fn threads_per_instance_default_is_four() {
+        // Remove the env var if set, then check the default
+        std::env::remove_var("LEAN_MCP_THREADS_PER_INSTANCE");
+        assert_eq!(threads_per_instance(), "4");
+    }
+
+    #[test]
+    fn threads_per_instance_respects_env_var() {
+        std::env::set_var("LEAN_MCP_THREADS_PER_INSTANCE", "8");
+        let result = threads_per_instance();
+        // Clean up before asserting so other tests aren't affected
+        std::env::remove_var("LEAN_MCP_THREADS_PER_INSTANCE");
+        assert_eq!(result, "8");
+    }
+
+    #[test]
+    fn threads_per_instance_ignores_empty_value() {
+        std::env::set_var("LEAN_MCP_THREADS_PER_INSTANCE", "");
+        let result = threads_per_instance();
+        std::env::remove_var("LEAN_MCP_THREADS_PER_INSTANCE");
+        assert_eq!(result, "4");
     }
 }


### PR DESCRIPTION
## Summary
- Adds `LEAN_NUM_THREADS` environment variable to the `lake serve` spawn in `spawn_lsp_client()`
- Configurable via `LEAN_MCP_THREADS_PER_INSTANCE` env var (defaults to `"4"`)
- Prevents CPU starvation when the auto-scaling pool runs multiple `lake serve` instances
- Adds `tracing::info!` log line showing the thread count on each spawn

## Test plan
- [x] Unit test: `threads_per_instance_default_is_four` — verifies default of 4
- [x] Unit test: `threads_per_instance_respects_env_var` — verifies custom value is used
- [x] Unit test: `threads_per_instance_ignores_empty_value` — verifies empty string falls back to default
- [x] All 800+ existing tests pass
- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo doc` all clean

Closes #130