### PR TITLE
feat: auto-rebuild stale imports on diagnostic detection (#132)

### DIFF
--- a/crates/lean-lsp-client/src/lean_client.rs
+++ b/crates/lean-lsp-client/src/lean_client.rs
@@ -1,7 +1,7 @@
 //! Real LSP client implementation connecting the [`LspClient`] trait to a
 //! [`Multiplexer`] for communication with a Lean 4 LSP server.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufRead, AsyncWrite};
 use tokio::sync::{mpsc, Mutex};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::client::{path_to_uri, LspClient, LspClientError};
 use crate::error::TransportError;
@@ -41,6 +41,10 @@ pub struct LeanLspClient {
     diag_tx: mpsc::UnboundedSender<String>,
     /// Receives URI updates when new diagnostics arrive.
     diag_rx: Arc<Mutex<mpsc::UnboundedReceiver<String>>>,
+    /// Tracks files for which a dependency rebuild (force-reopen) has already
+    /// been attempted after encountering "Imports are out of date" diagnostics.
+    /// Prevents infinite retry loops — each file is retried at most once.
+    dependency_rebuild_attempted: Arc<std::sync::Mutex<HashSet<String>>>,
 }
 
 /// Convert a [`MultiplexerError`] to an [`LspClientError`].
@@ -139,6 +143,7 @@ impl LeanLspClient {
             diagnostics,
             diag_tx,
             diag_rx: Arc::new(Mutex::new(diag_rx)),
+            dependency_rebuild_attempted: Arc::new(std::sync::Mutex::new(HashSet::new())),
         })
     }
 
@@ -359,6 +364,70 @@ impl LspClient for LeanLspClient {
             let map = self.diagnostics.lock().unwrap();
             map.get(&uri).cloned().unwrap_or_default()
         };
+
+        // Check for "Imports are out of date" error diagnostics.
+        // If found and not already attempted for this file, force-reopen
+        // the file and re-collect diagnostics.
+        let has_stale_imports = all_diags.iter().any(|d| {
+            d.get("severity").and_then(|s| s.as_u64()) == Some(1) // error
+                && d.get("message")
+                    .and_then(|m| m.as_str())
+                    .map(|m| m.contains("Imports are out of date"))
+                    .unwrap_or(false)
+        });
+
+        if has_stale_imports {
+            let already_attempted = {
+                let set = self.dependency_rebuild_attempted.lock().unwrap();
+                set.contains(relative_path)
+            };
+
+            if !already_attempted {
+                {
+                    let mut set = self.dependency_rebuild_attempted.lock().unwrap();
+                    set.insert(relative_path.to_string());
+                }
+
+                warn!(
+                    file = relative_path,
+                    "Stale imports detected, force-reopening file to rebuild dependencies"
+                );
+
+                // Force-reopen the file (close + reopen from disk).
+                self.open_file_force(relative_path).await?;
+
+                // Wait for new diagnostics to stabilize.
+                {
+                    let mut rx = self.diag_rx.lock().await;
+                    while let Ok(Some(_)) = tokio::time::timeout(timeout, rx.recv()).await {}
+                }
+
+                // Re-collect diagnostics after rebuild.
+                let rebuilt_diags = {
+                    let map = self.diagnostics.lock().unwrap();
+                    map.get(&uri).cloned().unwrap_or_default()
+                };
+
+                let filtered: Vec<Value> = if start_line.is_some() || end_line.is_some() {
+                    let start = start_line.unwrap_or(0);
+                    let end = end_line.unwrap_or(u32::MAX);
+                    rebuilt_diags
+                        .into_iter()
+                        .filter(|d| {
+                            d.get("range")
+                                .and_then(|r| r.get("start"))
+                                .and_then(|s| s.get("line"))
+                                .and_then(|l| l.as_u64())
+                                .map(|l| (l as u32) >= start && (l as u32) <= end)
+                                .unwrap_or(true)
+                        })
+                        .collect()
+                } else {
+                    rebuilt_diags
+                };
+                return Ok(json!(filtered));
+            }
+        }
 
         let filtered: Vec<Value> = if start_line.is_some() || end_line.is_some() {
             let start = start_line.unwrap_or(0);
@@ -1189,5 +1258,278 @@ mod tests {
             }
             other => panic!("Expected LspError, got: {other:?}"),
         }
+    }
+
+    // ── Stale imports auto-rebuild ──────────────────────────────────
+
+    #[tokio::test]
+    async fn test_stale_imports_triggers_force_reopen() {
+        let (client, mut sr, mut sw, dir) = setup().await;
+        open_test_file(&client, &mut sr, &dir, "Stale.lean", "import Mathlib").await;
+
+        let uri = path_to_uri(client.project_path(), "Stale.lean");
+
+        // Send diagnostics with "Imports are out of date" error.
+        let notif = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": uri,
+                "diagnostics": [{
+                    "range": {"start":{"line":0,"character":0},"end":{"line":0,"character":16}},
+                    "message": "Imports are out of date and must be rebuilt; use the \"Restart File\" command in your editor.",
+                    "severity": 1
+                }]
+            }
+        });
+        write_message(&mut sw, &notif).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // get_diagnostics should detect stale imports and force-reopen.
+        // The force-reopen sends didClose then didOpen. We need to drain
+        // those messages and send fresh diagnostics.
+        let diag_fut = client.get_diagnostics("Stale.lean", None, None, Some(0.2));
+
+        let server_fut = async {
+            // Expect didClose from force-reopen
+            let close_msg = read_message(&mut sr).await.unwrap();
+            assert_eq!(close_msg["method"], "textDocument/didClose");
+
+            // Expect didOpen from force-reopen
+            let open_msg = read_message(&mut sr).await.unwrap();
+            assert_eq!(open_msg["method"], "textDocument/didOpen");
+
+            // Send fresh diagnostics (no stale imports error this time)
+            let fresh_notif = json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": {
+                    "uri": uri,
+                    "diagnostics": [{
+                        "range": {"start":{"line":5,"character":0},"end":{"line":5,"character":10}},
+                        "message": "type mismatch",
+                        "severity": 1
+                    }]
+                }
+            });
+            write_message(&mut sw, &fresh_notif).await.unwrap();
+        };
+
+        let (result, _) = tokio::join!(diag_fut, server_fut);
+        let result = result.unwrap();
+        let diags = result.as_array().unwrap();
+        // Should return the fresh diagnostics, not the stale imports error.
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0]["message"], "type mismatch");
+    }
+
+    #[tokio::test]
+    async fn test_stale_imports_rebuild_only_attempted_once() {
+        let (client, mut sr, mut sw, dir) = setup().await;
+        open_test_file(&client, &mut sr, &dir, "Once.lean", "import Mathlib").await;
+
+        let uri = path_to_uri(client.project_path(), "Once.lean");
+
+        // First call: send stale imports diagnostic.
+        let stale_notif = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": uri,
+                "diagnostics": [{
+                    "range": {"start":{"line":0,"character":0},"end":{"line":0,"character":16}},
+                    "message": "Imports are out of date and must be rebuilt",
+                    "severity": 1
+                }]
+            }
+        });
+        write_message(&mut sw, &stale_notif).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // First get_diagnostics — should trigger rebuild.
+        let diag_fut = client.get_diagnostics("Once.lean", None, None, Some(0.2));
+        let server_fut = async {
+            let close_msg = read_message(&mut sr).await.unwrap();
+            assert_eq!(close_msg["method"], "textDocument/didClose");
+            let open_msg = read_message(&mut sr).await.unwrap();
+            assert_eq!(open_msg["method"], "textDocument/didOpen");
+
+            // Still send stale imports (simulating rebuild didn't fix it)
+            let notif = json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": {
+                    "uri": uri,
+                    "diagnostics": [{
+                        "range": {"start":{"line":0,"character":0},"end":{"line":0,"character":16}},
+                        "message": "Imports are out of date and must be rebuilt",
+                        "severity": 1
+                    }]
+                }
+            });
+            write_message(&mut sw, &notif).await.unwrap();
+        };
+        let (result, _) = tokio::join!(diag_fut, server_fut);
+        result.unwrap();
+
+        // Second call: send stale imports again. Should NOT trigger rebuild.
+        let stale_notif2 = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": uri,
+                "diagnostics": [{
+                    "range": {"start":{"line":0,"character":0},"end":{"line":0,"character":16}},
+                    "message": "Imports are out of date and must be rebuilt",
+                    "severity": 1
+                }]
+            }
+        });
+        write_message(&mut sw, &stale_notif2).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let result2 = client
+            .get_diagnostics("Once.lean", None, None, Some(0.2))
+            .await
+            .unwrap();
+
+        // Should return the stale imports error as-is (no rebuild attempted)
+        let diags = result2.as_array().unwrap();
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Imports are out of date"));
+
+        // Verify no didClose/didOpen was sent (would cause server read to block)
+        let read_result =
+            tokio::time::timeout(Duration::from_millis(100), read_message(&mut sr)).await;
+        assert!(
+            read_result.is_err(),
+            "Expected no message but got one — rebuild was attempted twice"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_normal_diagnostics_no_rebuild() {
+        let (client, mut sr, mut sw, dir) = setup().await;
+        open_test_file(&client, &mut sr, &dir, "Normal.lean", "def x := sorry").await;
+
+        let uri = path_to_uri(client.project_path(), "Normal.lean");
+
+        // Send normal error diagnostics (NOT stale imports).
+        let notif = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": uri,
+                "diagnostics": [{
+                    "range": {"start":{"line":0,"character":9},"end":{"line":0,"character":14}},
+                    "message": "declaration uses 'sorry'",
+                    "severity": 2
+                }]
+            }
+        });
+        write_message(&mut sw, &notif).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let result = client
+            .get_diagnostics("Normal.lean", None, None, Some(0.1))
+            .await
+            .unwrap();
+        let diags = result.as_array().unwrap();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0]["message"], "declaration uses 'sorry'");
+
+        // Verify no didClose/didOpen was sent — no rebuild for normal diagnostics
+        let read_result =
+            tokio::time::timeout(Duration::from_millis(100), read_message(&mut sr)).await;
+        assert!(
+            read_result.is_err(),
+            "Expected no message but got one — rebuild triggered for normal diagnostics"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stale_imports_different_files_tracked_separately() {
+        let (client, mut sr, mut sw, dir) = setup().await;
+        open_test_file(&client, &mut sr, &dir, "A.lean", "import X").await;
+        open_test_file(&client, &mut sr, &dir, "B.lean", "import Y").await;
+
+        let uri_a = path_to_uri(client.project_path(), "A.lean");
+        let uri_b = path_to_uri(client.project_path(), "B.lean");
+
+        // Trigger stale imports on A.lean
+        let notif_a = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": uri_a,
+                "diagnostics": [{
+                    "range": {"start":{"line":0,"character":0},"end":{"line":0,"character":8}},
+                    "message": "Imports are out of date",
+                    "severity": 1
+                }]
+            }
+        });
+        write_message(&mut sw, &notif_a).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // get_diagnostics for A should trigger rebuild
+        let diag_fut = client.get_diagnostics("A.lean", None, None, Some(0.2));
+        let server_fut = async {
+            let close_msg = read_message(&mut sr).await.unwrap();
+            assert_eq!(close_msg["method"], "textDocument/didClose");
+            let open_msg = read_message(&mut sr).await.unwrap();
+            assert_eq!(open_msg["method"], "textDocument/didOpen");
+
+            let fresh = json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": { "uri": uri_a, "diagnostics": [] }
+            });
+            write_message(&mut sw, &fresh).await.unwrap();
+        };
+        let (result, _) = tokio::join!(diag_fut, server_fut);
+        result.unwrap();
+
+        // Now trigger stale imports on B.lean — should still trigger rebuild
+        // because B.lean hasn't been attempted yet.
+        let notif_b = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": uri_b,
+                "diagnostics": [{
+                    "range": {"start":{"line":0,"character":0},"end":{"line":0,"character":8}},
+                    "message": "Imports are out of date",
+                    "severity": 1
+                }]
+            }
+        });
+        write_message(&mut sw, &notif_b).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let diag_fut = client.get_diagnostics("B.lean", None, None, Some(0.2));
+        let server_fut = async {
+            let close_msg = read_message(&mut sr).await.unwrap();
+            assert_eq!(close_msg["method"], "textDocument/didClose");
+            let open_msg = read_message(&mut sr).await.unwrap();
+            assert_eq!(open_msg["method"], "textDocument/didOpen");
+
+            let fresh = json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": { "uri": uri_b, "diagnostics": [] }
+            });
+            write_message(&mut sw, &fresh).await.unwrap();
+        };
+        let (result, _) = tokio::join!(diag_fut, server_fut);
+        let result = result.unwrap();
+        let diags = result.as_array().unwrap();
+        assert!(
+            diags.is_empty(),
+            "B.lean should have clean diagnostics after rebuild"
+        );
     }
 }


### PR DESCRIPTION
Closes #132

## Summary
- Detects "Imports are out of date" error diagnostics in `LeanLspClient::get_diagnostics()`
- Automatically closes and force-reopens the file to trigger dependency rebuild
- Tracks per-file rebuild attempts via `dependency_rebuild_attempted` HashSet to prevent infinite retry loops
- Logs a `tracing::warn!` when stale imports are detected and rebuild is attempted

## Test plan
- [x] Unit test: stale imports triggers force-reopen and returns updated diagnostics
- [x] Unit test: rebuild only attempted once per file (second call returns stale error as-is)
- [x] Unit test: normal diagnostics do not trigger rebuild
- [x] Unit test: different files tracked separately (A.lean rebuild doesn't block B.lean)
- [x] All 817 existing tests still pass
- [x] `cargo fmt`, `cargo clippy`, `cargo doc` all pass