### PR TITLE
feat: add file_context parameter to lean_run_code for project-faithful compilation (#145)

### DIFF
--- a/crates/lean-mcp-server/src/server.rs
+++ b/crates/lean-mcp-server/src/server.rs
@@ -176,6 +176,10 @@ pub struct MultiAttemptAsyncParams {
 pub struct RunCodeParams {
     #[schemars(description = "Self-contained Lean code with imports")]
     pub code: String,
+    #[schemars(
+        description = "Path to a project file whose content provides compilation context. The code snippet is appended to this file's content for compilation, inheriting its imports, namespaces, and section variables."
+    )]
+    pub file_context: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -1177,19 +1181,24 @@ impl AppContext {
 
     #[tool(
         name = "lean_run_code",
-        description = "Run a code snippet and return diagnostics. Must include all imports."
+        description = "Run a code snippet and return diagnostics. Must include all imports. Use file_context to compile in the context of an existing project file."
     )]
     async fn lean_run_code(
         &self,
         Parameters(params): Parameters<RunCodeParams>,
     ) -> Result<String, String> {
         let _t = ToolTimer::new("lean_run_code");
-        let project_path = self.resolve_project_path(None)?;
+        let project_path = self.resolve_project_path(params.file_context.as_deref())?;
         let client = self.ensure_client_for(&project_path).await?;
-        tools::run_code::handle_run_code(client.as_ref(), &project_path, &params.code)
-            .await
-            .map(|r| Self::to_json(&r))
-            .map_err(|e| e.to_string())
+        tools::run_code::handle_run_code(
+            client.as_ref(),
+            &project_path,
+            &params.code,
+            params.file_context.as_deref(),
+        )
+        .await
+        .map(|r| Self::to_json(&r))
+        .map_err(|e| e.to_string())
     }
 
     // ---- Verify Theorem ----

--- a/crates/lean-mcp-server/src/tools/batch.rs
+++ b/crates/lean-mcp-server/src/tools/batch.rs
@@ -135,6 +135,7 @@ struct MultiAttemptArgs {
 #[derive(Deserialize)]
 struct RunCodeArgs {
     code: String,
+    file_context: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -378,7 +379,7 @@ async fn dispatch_inner(
             let a: RunCodeArgs = deser(args)?;
             let c = require_client(client)?;
             let pp = require_project(project_path)?;
-            let r = super::run_code::handle_run_code(c, pp, &a.code)
+            let r = super::run_code::handle_run_code(c, pp, &a.code, a.file_context.as_deref())
                 .await
                 .map_err(|e| e.to_string())?;
             to_json(&r)

--- a/crates/lean-mcp-server/src/tools/run_code.rs
+++ b/crates/lean-mcp-server/src/tools/run_code.rs
@@ -14,11 +14,25 @@ use uuid::Uuid;
 /// Convert raw LSP diagnostics into [`DiagnosticMessage`] items.
 ///
 /// Mirrors the Python `_to_diagnostic_messages` helper.
-fn to_diagnostic_messages(diagnostics: &[Value]) -> Vec<DiagnosticMessage> {
+///
+/// When `context_lines` is provided (> 0), diagnostics from lines before
+/// `context_lines` (0-indexed) are filtered out, and line numbers in the
+/// remaining diagnostics are adjusted so they are relative to the snippet.
+fn to_diagnostic_messages(diagnostics: &[Value], context_lines: usize) -> Vec<DiagnosticMessage> {
     let mut items = Vec::new();
     for diag in diagnostics {
         let range = diag.get("fullRange").or_else(|| diag.get("range"));
         let Some(r) = range else { continue };
+
+        let raw_line = r
+            .pointer("/start/line")
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+
+        // Filter out diagnostics from the context region.
+        if context_lines > 0 && (raw_line as usize) < context_lines {
+            continue;
+        }
 
         let severity_int = diag.get("severity").and_then(Value::as_i64).unwrap_or(1);
         let sev_name = match severity_int as i32 {
@@ -30,11 +44,8 @@ fn to_diagnostic_messages(diagnostics: &[Value]) -> Vec<DiagnosticMessage> {
         };
 
         let message = diag.get("message").and_then(Value::as_str).unwrap_or("");
-        let line = r
-            .pointer("/start/line")
-            .and_then(Value::as_i64)
-            .unwrap_or(0)
-            + 1;
+        // Adjust line number relative to snippet (subtract context lines).
+        let line = raw_line - context_lines as i64 + 1;
         let column = r
             .pointer("/start/character")
             .and_then(Value::as_i64)
@@ -57,12 +68,19 @@ fn to_diagnostic_messages(diagnostics: &[Value]) -> Vec<DiagnosticMessage> {
 /// in the LSP server, collects diagnostics, then always closes and deletes
 /// the temp file.
 ///
+/// When `file_context` is provided, the content of the given file is read
+/// and prepended to the snippet so it inherits the file's imports,
+/// namespaces, and section variables. Diagnostics from the context region
+/// are filtered out and line numbers are adjusted to be relative to the
+/// snippet.
+///
 /// Returns a [`RunResult`] with `success = true` when there are no error
 /// diagnostics.
 pub async fn handle_run_code(
     client: &dyn LspClient,
     project_path: &Path,
     code: &str,
+    file_context: Option<&str>,
 ) -> Result<RunResult, LeanToolError> {
     // 1. Generate UUID-based temp filename inside .lake/_mcp/ to avoid git pollution.
     let mcp_dir = project_path.join(".lake").join("_mcp");
@@ -72,9 +90,32 @@ pub async fn handle_run_code(
     let abs_path = mcp_dir.join(&filename);
     let rel_path = format!(".lake/_mcp/{filename}");
 
-    // 2. Inject maxHeartbeats to prevent runaway elaboration, then write.
-    let code_with_heartbeats = super::prepend_max_heartbeats(code);
-    std::fs::write(&abs_path, &code_with_heartbeats)
+    // 2. Build the file content, optionally prepending context from an existing file.
+    let (file_content, context_lines) = if let Some(ctx_path) = file_context {
+        // Read the context file. Try the absolute path first, then relative to project.
+        let abs_ctx = if Path::new(ctx_path).is_absolute() {
+            Path::new(ctx_path).to_path_buf()
+        } else {
+            project_path.join(ctx_path)
+        };
+        let context_content = std::fs::read_to_string(&abs_ctx).map_err(|e| {
+            LeanToolError::Other(format!(
+                "Error reading file_context '{}': {e}",
+                abs_ctx.display()
+            ))
+        })?;
+        let ctx_lines = context_content.lines().count();
+        // When using file_context, skip maxHeartbeats injection since
+        // the context file may have its own options.
+        let combined = format!("{}\n{}", context_content, code);
+        (combined, ctx_lines)
+    } else {
+        // No context: inject maxHeartbeats as before.
+        let code_with_heartbeats = super::prepend_max_heartbeats(code);
+        (code_with_heartbeats, 0)
+    };
+
+    std::fs::write(&abs_path, &file_content)
         .map_err(|e| LeanToolError::Other(format!("Error writing code snippet: {e}")))?;
 
     // 3. Open in LSP, get diagnostics -- always clean up afterwards.
@@ -101,7 +142,7 @@ pub async fn handle_run_code(
             .cloned()
             .unwrap_or_default();
 
-        let diagnostics = to_diagnostic_messages(&diagnostics_arr);
+        let diagnostics = to_diagnostic_messages(&diagnostics_arr, context_lines);
         let has_errors = diagnostics.iter().any(|d| d.severity == "error");
 
         Ok(RunResult {
@@ -320,7 +361,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let client = MockRunClient::new(dir.path().to_path_buf());
 
-        let result = handle_run_code(&client, dir.path(), "def foo := 42")
+        let result = handle_run_code(&client, dir.path(), "def foo := 42", None)
             .await
             .unwrap();
 
@@ -342,7 +383,7 @@ mod tests {
             "message": "unknown identifier 'bad'"
         })]);
 
-        let result = handle_run_code(&client, dir.path(), "def x := bad")
+        let result = handle_run_code(&client, dir.path(), "def x := bad", None)
             .await
             .unwrap();
 
@@ -361,7 +402,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let client = MockRunClient::new(dir.path().to_path_buf());
 
-        let _ = handle_run_code(&client, dir.path(), "#check Nat")
+        let _ = handle_run_code(&client, dir.path(), "#check Nat", None)
             .await
             .unwrap();
 
@@ -558,7 +599,7 @@ mod tests {
             opened: std::sync::Mutex::new(Vec::new()),
         };
 
-        let _ = handle_run_code(&client, dir.path(), "#check Nat")
+        let _ = handle_run_code(&client, dir.path(), "#check Nat", None)
             .await
             .unwrap();
 
@@ -579,7 +620,7 @@ mod tests {
         let client = MockRunClient::new(dir.path().to_path_buf());
         let close_flag = client.close_called.clone();
 
-        let _ = handle_run_code(&client, dir.path(), "#check Nat").await;
+        let _ = handle_run_code(&client, dir.path(), "#check Nat", None).await;
 
         assert!(
             close_flag.load(Ordering::SeqCst),
@@ -601,7 +642,7 @@ mod tests {
             "message": "unused variable"
         })]);
 
-        let result = handle_run_code(&client, dir.path(), "def x := 42")
+        let result = handle_run_code(&client, dir.path(), "def x := 42", None)
             .await
             .unwrap();
 
@@ -628,7 +669,7 @@ mod tests {
             }),
         ];
 
-        let items = to_diagnostic_messages(&diags);
+        let items = to_diagnostic_messages(&diags, 0);
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].severity, "error");
         assert_eq!(items[0].line, 5);
@@ -645,7 +686,321 @@ mod tests {
             "severity": 1,
             "message": "no range"
         })];
-        let items = to_diagnostic_messages(&diags);
+        let items = to_diagnostic_messages(&diags, 0);
         assert!(items.is_empty());
+    }
+
+    // ---- file_context tests ----
+
+    #[test]
+    fn to_diagnostic_messages_filters_context_lines() {
+        // Simulate context file with 10 lines; diagnostics from context (line 3)
+        // and snippet (line 12) regions.
+        let diags = vec![
+            json!({
+                "range": {"start": {"line": 3, "character": 0}, "end": {"line": 3, "character": 5}},
+                "severity": 1,
+                "message": "context error"
+            }),
+            json!({
+                "range": {"start": {"line": 12, "character": 4}, "end": {"line": 12, "character": 10}},
+                "severity": 1,
+                "message": "snippet error"
+            }),
+        ];
+
+        let items = to_diagnostic_messages(&diags, 10);
+        // Only the snippet diagnostic should remain.
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].message, "snippet error");
+        // Line 12 (0-indexed) - 10 context lines + 1 (1-indexed) = 3
+        assert_eq!(items[0].line, 3);
+        assert_eq!(items[0].column, 5);
+    }
+
+    #[test]
+    fn to_diagnostic_messages_adjusts_line_numbers_with_context() {
+        // Context has 5 lines; diagnostic at 0-indexed line 5 => snippet line 1.
+        let diags = vec![json!({
+            "range": {"start": {"line": 5, "character": 0}, "end": {"line": 5, "character": 5}},
+            "severity": 2,
+            "message": "warning in snippet"
+        })];
+
+        let items = to_diagnostic_messages(&diags, 5);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].line, 1);
+        assert_eq!(items[0].severity, "warning");
+    }
+
+    #[tokio::test]
+    async fn run_code_with_file_context_prepends_content() {
+        let dir = TempDir::new().unwrap();
+        // Create a context file with some imports.
+        let ctx_file = dir.path().join("MyModule.lean");
+        std::fs::write(&ctx_file, "import Init\n\ndef helper := 42\n").unwrap();
+
+        // Create .lake/_mcp so the handler can write temp files.
+        std::fs::create_dir_all(dir.path().join(".lake").join("_mcp")).unwrap();
+
+        // Mock client that captures the written file content.
+        struct ContentCapturingClient {
+            project: PathBuf,
+        }
+
+        #[async_trait]
+        impl LspClient for ContentCapturingClient {
+            fn project_path(&self) -> &Path {
+                &self.project
+            }
+            async fn open_file(
+                &self,
+                p: &str,
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                // Verify the temp file contains the context content.
+                let abs = self.project.join(p);
+                let content = std::fs::read_to_string(&abs).unwrap();
+                assert!(
+                    content.starts_with("import Init"),
+                    "temp file should start with context content, got: {content}"
+                );
+                assert!(
+                    content.contains("def helper := 42"),
+                    "temp file should contain context content"
+                );
+                assert!(
+                    content.contains("#check helper"),
+                    "temp file should contain snippet code"
+                );
+                // Verify maxHeartbeats is NOT injected when file_context is used.
+                assert!(
+                    !content.contains("maxHeartbeats"),
+                    "maxHeartbeats should not be injected with file_context"
+                );
+                Ok(())
+            }
+            async fn open_file_force(
+                &self,
+                _p: &str,
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+            async fn get_file_content(
+                &self,
+                _p: &str,
+            ) -> Result<String, lean_lsp_client::client::LspClientError> {
+                Ok(String::new())
+            }
+            async fn update_file(
+                &self,
+                _p: &str,
+                _c: Vec<Value>,
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+            async fn update_file_content(
+                &self,
+                _p: &str,
+                _c: &str,
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+            async fn close_files(
+                &self,
+                _p: &[String],
+            ) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+            async fn get_diagnostics(
+                &self,
+                _p: &str,
+                _sl: Option<u32>,
+                _el: Option<u32>,
+                _t: Option<f64>,
+            ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+                // Return a diagnostic in the context region (should be filtered)
+                // and one in the snippet region (should be kept).
+                // Context is 3 lines ("import Init\n\ndef helper := 42\n"),
+                // so snippet starts at 0-indexed line 3.
+                Ok(json!({
+                    "diagnostics": [
+                        {
+                            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 5}},
+                            "severity": 3,
+                            "message": "context info"
+                        },
+                        {
+                            "range": {"start": {"line": 3, "character": 0}, "end": {"line": 3, "character": 10}},
+                            "severity": 3,
+                            "message": "snippet info"
+                        }
+                    ],
+                    "success": true
+                }))
+            }
+            async fn get_interactive_diagnostics(
+                &self,
+                _p: &str,
+                _sl: Option<u32>,
+                _el: Option<u32>,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_goal(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(None)
+            }
+            async fn get_term_goal(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(None)
+            }
+            async fn get_hover(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Option<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(None)
+            }
+            async fn get_completions(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_declarations(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_references(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+                _d: bool,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_document_symbols(
+                &self,
+                _p: &str,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_code_actions(
+                &self,
+                _p: &str,
+                _sl: u32,
+                _sc: u32,
+                _el: u32,
+                _ec: u32,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_code_action_resolve(
+                &self,
+                _a: Value,
+            ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+                Ok(json!({}))
+            }
+            async fn get_widgets(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+            ) -> Result<Vec<Value>, lean_lsp_client::client::LspClientError> {
+                Ok(vec![])
+            }
+            async fn get_widget_source(
+                &self,
+                _p: &str,
+                _l: u32,
+                _c: u32,
+                _h: &str,
+            ) -> Result<Value, lean_lsp_client::client::LspClientError> {
+                Ok(json!({}))
+            }
+            async fn shutdown(&self) -> Result<(), lean_lsp_client::client::LspClientError> {
+                Ok(())
+            }
+        }
+
+        let client = ContentCapturingClient {
+            project: dir.path().to_path_buf(),
+        };
+
+        let result = handle_run_code(
+            &client,
+            dir.path(),
+            "#check helper",
+            Some(ctx_file.to_str().unwrap()),
+        )
+        .await
+        .unwrap();
+
+        // Only the snippet diagnostic should be returned.
+        assert!(result.success);
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.diagnostics[0].message, "snippet info");
+        // 0-indexed line 3 - 3 context lines + 1 = 1
+        assert_eq!(result.diagnostics[0].line, 1);
+    }
+
+    #[tokio::test]
+    async fn run_code_without_file_context_unchanged() {
+        // Verify that calling without file_context behaves exactly as before.
+        let dir = TempDir::new().unwrap();
+        let client = MockRunClient::new(dir.path().to_path_buf()).with_diagnostics(vec![json!({
+            "range": {
+                "start": {"line": 2, "character": 0},
+                "end": {"line": 2, "character": 5}
+            },
+            "severity": 1,
+            "message": "some error"
+        })]);
+
+        let result = handle_run_code(&client, dir.path(), "def x := bad", None)
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert_eq!(result.diagnostics.len(), 1);
+        // Line should be 2 (0-indexed) + 1 = 3 with no context adjustment.
+        assert_eq!(result.diagnostics[0].line, 3);
+    }
+
+    #[tokio::test]
+    async fn run_code_file_context_missing_file_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let client = MockRunClient::new(dir.path().to_path_buf());
+
+        let result = handle_run_code(
+            &client,
+            dir.path(),
+            "#check Nat",
+            Some("/nonexistent/path/File.lean"),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Error reading file_context"),
+            "expected file read error, got: {err_msg}"
+        );
     }
 }


### PR DESCRIPTION
Closes #145

## Summary
- Adds optional `file_context` parameter to `lean_run_code` that specifies a project file whose content is prepended to the snippet for compilation
- The snippet inherits the context file's imports, namespaces, and section variables, so code that passes `lean_run_code` will also work when written into that file
- Diagnostics from the context region are filtered out and line numbers are adjusted to be relative to the snippet
- When `file_context` is not provided, behavior is unchanged (backward compatible)
- `maxHeartbeats` injection is skipped when `file_context` is used since the context file may have its own options
- Batch tool (`lean_run_code` via `lean_batch`) also supports the new parameter

## Test plan
- [x] Existing tests pass with `None` file_context (backward compatibility)
- [x] `to_diagnostic_messages` filters context-region diagnostics correctly
- [x] `to_diagnostic_messages` adjusts line numbers when context lines > 0
- [x] `run_code_with_file_context_prepends_content` verifies context content is prepended, maxHeartbeats is skipped, and diagnostics are filtered
- [x] `run_code_without_file_context_unchanged` confirms no regression
- [x] `run_code_file_context_missing_file_returns_error` validates error handling
- [x] All CI checks: `cargo test --all`, `cargo fmt`, `cargo clippy -D warnings`, `cargo doc`